### PR TITLE
Phase 4: Sync & polish — Firestore sync, delta ingestion, notifications

### DIFF
--- a/lib/src/providers/auth_provider.dart
+++ b/lib/src/providers/auth_provider.dart
@@ -1,0 +1,21 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final firebaseAuthProvider = Provider<FirebaseAuth>((ref) {
+  return FirebaseAuth.instance;
+});
+
+/// Manages anonymous authentication for Firestore user isolation.
+final authStateProvider = StreamProvider<User?>((ref) {
+  return ref.watch(firebaseAuthProvider).authStateChanges();
+});
+
+/// Signs in anonymously if not already signed in.
+/// Returns the user ID for Firestore path construction.
+Future<String?> ensureSignedIn(FirebaseAuth auth) async {
+  if (auth.currentUser != null) {
+    return auth.currentUser!.uid;
+  }
+  final credential = await auth.signInAnonymously();
+  return credential.user?.uid;
+}

--- a/lib/src/storage/graph_migrator.dart
+++ b/lib/src/storage/graph_migrator.dart
@@ -1,0 +1,29 @@
+import '../models/knowledge_graph.dart';
+import 'graph_repository.dart';
+
+/// Migrates a knowledge graph from one repository to another.
+///
+/// Used for local JSON → Firestore migration when cloud sync is first enabled,
+/// and for Firestore → local fallback when cloud sync is disabled.
+class GraphMigrator {
+  const GraphMigrator({
+    required GraphRepository source,
+    required GraphRepository destination,
+  })  : _source = source,
+        _destination = destination;
+
+  final GraphRepository _source;
+  final GraphRepository _destination;
+
+  /// Load from source and save to destination.
+  /// Returns the migrated graph, or [KnowledgeGraph.empty] if source is empty.
+  Future<KnowledgeGraph> migrate() async {
+    final graph = await _source.load();
+    if (graph.concepts.isNotEmpty ||
+        graph.quizItems.isNotEmpty ||
+        graph.documentMetadata.isNotEmpty) {
+      await _destination.save(graph);
+    }
+    return graph;
+  }
+}

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -1,0 +1,421 @@
+import 'dart:convert';
+
+import 'package:engram/src/models/document_metadata.dart';
+import 'package:engram/src/models/knowledge_graph.dart';
+import 'package:engram/src/models/sync_status.dart';
+import 'package:engram/src/providers/knowledge_graph_provider.dart';
+import 'package:engram/src/providers/service_providers.dart';
+import 'package:engram/src/providers/settings_provider.dart';
+import 'package:engram/src/providers/sync_provider.dart';
+import 'package:engram/src/services/extraction_service.dart';
+import 'package:engram/src/services/outline_client.dart';
+import 'package:engram/src/storage/settings_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+class MockExtractionService extends Mock implements ExtractionService {}
+
+/// Returns an HTTP response listing the given collections.
+String _collectionsJson(List<Map<String, String>> collections) {
+  return jsonEncode({
+    'data': collections,
+    'pagination': {'total': collections.length},
+  });
+}
+
+void main() {
+  group('SyncNotifier', () {
+    late MockExtractionService mockExtraction;
+    late SharedPreferences prefs;
+    late SettingsRepository settingsRepo;
+
+    setUp(() async {
+      mockExtraction = MockExtractionService();
+      SharedPreferences.setMockInitialValues({
+        'outline_api_url': 'https://wiki.test.com',
+        'outline_api_key': 'test-key',
+        'anthropic_api_key': 'sk-ant-test',
+        'ingested_collection_ids': ['col1'],
+      });
+      prefs = await SharedPreferences.getInstance();
+      settingsRepo = SettingsRepository(prefs);
+    });
+
+    ProviderContainer createContainer({
+      required http.Client httpClient,
+      KnowledgeGraph? graph,
+    }) {
+      return ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          dataDirProvider.overrideWithValue('/tmp/engram_test'),
+          settingsRepositoryProvider.overrideWithValue(settingsRepo),
+          knowledgeGraphProvider
+              .overrideWith(() => _PreloadedGraphNotifier(
+                    graph ?? KnowledgeGraph.empty,
+                  )),
+          outlineClientProvider.overrideWithValue(
+            OutlineClient(
+              apiUrl: 'https://wiki.test.com',
+              apiKey: 'test-key',
+              httpClient: httpClient,
+            ),
+          ),
+          extractionServiceProvider.overrideWithValue(mockExtraction),
+        ],
+      );
+    }
+
+    test('initial state is idle', () async {
+      final client = MockClient((_) async => http.Response('{}', 200));
+      final container = createContainer(httpClient: client);
+      final state = container.read(syncProvider);
+      expect(state.phase, SyncPhase.idle);
+    });
+
+    test('checkForUpdates finds stale documents', () async {
+      const graph = KnowledgeGraph(
+        documentMetadata: [
+          DocumentMetadata(
+            documentId: 'doc1',
+            title: 'Docker Guide',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            ingestedAt: '2025-01-01T12:00:00.000Z',
+          ),
+        ],
+      );
+
+      final client = MockClient((request) async {
+        if (request.url.path == '/api/collections.list') {
+          return http.Response(
+            _collectionsJson([{'id': 'col1', 'name': 'DevOps'}]),
+            200,
+          );
+        }
+        if (request.url.path == '/api/documents.list') {
+          return http.Response(
+            jsonEncode({
+              'data': [
+                {
+                  'id': 'doc1',
+                  'title': 'Docker Guide',
+                  'updatedAt': '2025-02-01T00:00:00.000Z', // newer
+                },
+              ],
+              'pagination': {'total': 1},
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final container = createContainer(httpClient: client, graph: graph);
+      await container.read(knowledgeGraphProvider.future);
+      await container.read(syncProvider.notifier).checkForUpdates();
+
+      final state = container.read(syncProvider);
+      expect(state.phase, SyncPhase.updatesAvailable);
+      expect(state.staleDocumentCount, 1);
+      expect(state.staleCollectionIds, ['col1']);
+    });
+
+    test('checkForUpdates reports up-to-date when no changes', () async {
+      const graph = KnowledgeGraph(
+        documentMetadata: [
+          DocumentMetadata(
+            documentId: 'doc1',
+            title: 'Docker Guide',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            ingestedAt: '2025-01-01T12:00:00.000Z',
+          ),
+        ],
+      );
+
+      final client = MockClient((request) async {
+        if (request.url.path == '/api/collections.list') {
+          return http.Response(
+            _collectionsJson([{'id': 'col1', 'name': 'DevOps'}]),
+            200,
+          );
+        }
+        if (request.url.path == '/api/documents.list') {
+          return http.Response(
+            jsonEncode({
+              'data': [
+                {
+                  'id': 'doc1',
+                  'title': 'Docker Guide',
+                  'updatedAt': '2025-01-01T00:00:00.000Z', // same
+                },
+              ],
+              'pagination': {'total': 1},
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final container = createContainer(httpClient: client, graph: graph);
+      await container.read(knowledgeGraphProvider.future);
+      await container.read(syncProvider.notifier).checkForUpdates();
+
+      final state = container.read(syncProvider);
+      expect(state.phase, SyncPhase.upToDate);
+    });
+
+    test('checkForUpdates detects new documents in existing collection', () async {
+      // Graph has doc1, but Outline returns doc1 + doc2 (new)
+      const graph = KnowledgeGraph(
+        documentMetadata: [
+          DocumentMetadata(
+            documentId: 'doc1',
+            title: 'Docker Guide',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            ingestedAt: '2025-01-01T12:00:00.000Z',
+          ),
+        ],
+      );
+
+      final client = MockClient((request) async {
+        if (request.url.path == '/api/collections.list') {
+          return http.Response(
+            _collectionsJson([{'id': 'col1', 'name': 'DevOps'}]),
+            200,
+          );
+        }
+        if (request.url.path == '/api/documents.list') {
+          return http.Response(
+            jsonEncode({
+              'data': [
+                {
+                  'id': 'doc1',
+                  'title': 'Docker Guide',
+                  'updatedAt': '2025-01-01T00:00:00.000Z', // unchanged
+                },
+                {
+                  'id': 'doc2',
+                  'title': 'Kubernetes Guide',
+                  'updatedAt': '2025-02-01T00:00:00.000Z', // new doc
+                },
+              ],
+              'pagination': {'total': 2},
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final container = createContainer(httpClient: client, graph: graph);
+      await container.read(knowledgeGraphProvider.future);
+      await container.read(syncProvider.notifier).checkForUpdates();
+
+      final state = container.read(syncProvider);
+      expect(state.phase, SyncPhase.updatesAvailable);
+      expect(state.staleDocumentCount, 1); // doc2 is new
+    });
+
+    test('checkForUpdates reports up-to-date when no collections exist', () async {
+      // Override with empty ingested collection list
+      SharedPreferences.setMockInitialValues({
+        'outline_api_url': 'https://wiki.test.com',
+        'outline_api_key': 'test-key',
+        'anthropic_api_key': 'sk-ant-test',
+      });
+      prefs = await SharedPreferences.getInstance();
+      settingsRepo = SettingsRepository(prefs);
+
+      const graph = KnowledgeGraph(
+        documentMetadata: [
+          DocumentMetadata(
+            documentId: 'doc1',
+            title: 'Docker Guide',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            ingestedAt: '2025-01-01T12:00:00.000Z',
+          ),
+        ],
+      );
+
+      // Outline also has no collections
+      final client = MockClient((request) async {
+        if (request.url.path == '/api/collections.list') {
+          return http.Response(_collectionsJson([]), 200);
+        }
+        return http.Response('{}', 200);
+      });
+      final container = createContainer(httpClient: client, graph: graph);
+      await container.read(knowledgeGraphProvider.future);
+      await container.read(syncProvider.notifier).checkForUpdates();
+
+      final state = container.read(syncProvider);
+      expect(state.phase, SyncPhase.upToDate);
+    });
+
+    test('checkForUpdates discovers new collections in Outline', () async {
+      // col1 is ingested, but Outline now has col1 + col2
+      const graph = KnowledgeGraph(
+        documentMetadata: [
+          DocumentMetadata(
+            documentId: 'doc1',
+            title: 'Docker Guide',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            ingestedAt: '2025-01-01T12:00:00.000Z',
+          ),
+        ],
+      );
+
+      final client = MockClient((request) async {
+        if (request.url.path == '/api/collections.list') {
+          return http.Response(
+            _collectionsJson([
+              {'id': 'col1', 'name': 'DevOps'},
+              {'id': 'col2', 'name': 'Kubernetes'},
+            ]),
+            200,
+          );
+        }
+        if (request.url.path == '/api/documents.list') {
+          return http.Response(
+            jsonEncode({
+              'data': [
+                {
+                  'id': 'doc1',
+                  'title': 'Docker Guide',
+                  'updatedAt': '2025-01-01T00:00:00.000Z', // unchanged
+                },
+              ],
+              'pagination': {'total': 1},
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final container = createContainer(httpClient: client, graph: graph);
+      await container.read(knowledgeGraphProvider.future);
+      await container.read(syncProvider.notifier).checkForUpdates();
+
+      final state = container.read(syncProvider);
+      expect(state.phase, SyncPhase.updatesAvailable);
+      expect(state.staleDocumentCount, 0); // no stale docs
+      expect(state.newCollections, hasLength(1));
+      expect(state.newCollections.first['name'], 'Kubernetes');
+    });
+
+    test('dismissNewCollections clears banner and returns to upToDate', () async {
+      const graph = KnowledgeGraph(
+        documentMetadata: [
+          DocumentMetadata(
+            documentId: 'doc1',
+            title: 'Docker Guide',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            ingestedAt: '2025-01-01T12:00:00.000Z',
+          ),
+        ],
+      );
+
+      final client = MockClient((request) async {
+        if (request.url.path == '/api/collections.list') {
+          return http.Response(
+            _collectionsJson([
+              {'id': 'col1', 'name': 'DevOps'},
+              {'id': 'col2', 'name': 'Kubernetes'},
+            ]),
+            200,
+          );
+        }
+        if (request.url.path == '/api/documents.list') {
+          return http.Response(
+            jsonEncode({
+              'data': [
+                {
+                  'id': 'doc1',
+                  'title': 'Docker Guide',
+                  'updatedAt': '2025-01-01T00:00:00.000Z',
+                },
+              ],
+              'pagination': {'total': 1},
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final container = createContainer(httpClient: client, graph: graph);
+      await container.read(knowledgeGraphProvider.future);
+      await container.read(syncProvider.notifier).checkForUpdates();
+
+      // Verify new collections detected
+      expect(container.read(syncProvider).newCollections, hasLength(1));
+
+      // Dismiss
+      container.read(syncProvider.notifier).dismissNewCollections();
+
+      final state = container.read(syncProvider);
+      expect(state.newCollections, isEmpty);
+      expect(state.phase, SyncPhase.upToDate);
+    });
+
+    test('checkForUpdates handles API errors gracefully', () async {
+      const graph = KnowledgeGraph(
+        documentMetadata: [
+          DocumentMetadata(
+            documentId: 'doc1',
+            title: 'Docker Guide',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            ingestedAt: '2025-01-01T12:00:00.000Z',
+          ),
+        ],
+      );
+
+      final client = MockClient((_) async => http.Response('error', 500));
+      final container = createContainer(httpClient: client, graph: graph);
+      await container.read(knowledgeGraphProvider.future);
+      await container.read(syncProvider.notifier).checkForUpdates();
+
+      final state = container.read(syncProvider);
+      expect(state.phase, SyncPhase.error);
+      expect(state.errorMessage, contains('Sync check failed'));
+    });
+
+    test('reset returns to idle', () async {
+      final client = MockClient((_) async => http.Response('{}', 200));
+      final container = createContainer(httpClient: client);
+
+      container.read(syncProvider.notifier).reset();
+      expect(container.read(syncProvider).phase, SyncPhase.idle);
+    });
+  });
+}
+
+class _PreloadedGraphNotifier extends KnowledgeGraphNotifier {
+  _PreloadedGraphNotifier(this._graph);
+  KnowledgeGraph _graph;
+
+  @override
+  Future<KnowledgeGraph> build() async => _graph;
+
+  @override
+  Future<void> ingestExtraction(
+    ExtractionResult result, {
+    required String documentId,
+    required String documentTitle,
+    required String updatedAt,
+  }) async {
+    _graph = _graph.withNewExtraction(
+      result,
+      documentId: documentId,
+      documentTitle: documentTitle,
+      updatedAt: updatedAt,
+    );
+    state = AsyncData(_graph);
+  }
+}

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -1,0 +1,156 @@
+import 'package:engram/src/services/notification_service.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+class MockFlutterLocalNotificationsPlugin extends Mock
+    implements FlutterLocalNotificationsPlugin {}
+
+class FakeInitializationSettings extends Fake
+    implements InitializationSettings {}
+
+class FakeNotificationDetails extends Fake implements NotificationDetails {}
+
+class FakeTZDateTime extends Fake implements tz.TZDateTime {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeInitializationSettings());
+    registerFallbackValue(FakeNotificationDetails());
+    registerFallbackValue(FakeTZDateTime());
+    registerFallbackValue(AndroidScheduleMode.inexactAllowWhileIdle);
+    registerFallbackValue(DateTimeComponents.time);
+  });
+
+  group('NotificationService', () {
+    late MockFlutterLocalNotificationsPlugin mockPlugin;
+    late NotificationService service;
+
+    setUp(() {
+      mockPlugin = MockFlutterLocalNotificationsPlugin();
+      service = NotificationService.withPlugin(mockPlugin);
+    });
+
+    test('initialize calls plugin.initialize', () async {
+      when(() => mockPlugin.initialize(
+            settings: any(named: 'settings'),
+            onDidReceiveNotificationResponse:
+                any(named: 'onDidReceiveNotificationResponse'),
+          )).thenAnswer((_) async => true);
+
+      await service.initialize();
+
+      verify(() => mockPlugin.initialize(
+            settings: any(named: 'settings'),
+            onDidReceiveNotificationResponse:
+                any(named: 'onDidReceiveNotificationResponse'),
+          )).called(1);
+    });
+
+    test('initialize only runs once', () async {
+      when(() => mockPlugin.initialize(
+            settings: any(named: 'settings'),
+            onDidReceiveNotificationResponse:
+                any(named: 'onDidReceiveNotificationResponse'),
+          )).thenAnswer((_) async => true);
+
+      await service.initialize();
+      await service.initialize();
+
+      verify(() => mockPlugin.initialize(
+            settings: any(named: 'settings'),
+            onDidReceiveNotificationResponse:
+                any(named: 'onDidReceiveNotificationResponse'),
+          )).called(1);
+    });
+
+    test('cancelAll delegates to plugin', () async {
+      when(() => mockPlugin.cancelAll()).thenAnswer((_) async {});
+
+      await service.cancelAll();
+
+      verify(() => mockPlugin.cancelAll()).called(1);
+    });
+
+    test('scheduleReviewReminder cancels then schedules', () async {
+      when(() => mockPlugin.cancelAll()).thenAnswer((_) async {});
+      when(() => mockPlugin.zonedSchedule(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            scheduledDate: any(named: 'scheduledDate'),
+            notificationDetails: any(named: 'notificationDetails'),
+            androidScheduleMode: any(named: 'androidScheduleMode'),
+            matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+          )).thenAnswer((_) async {});
+
+      await service.scheduleReviewReminder(
+        hour: 9,
+        title: '3-day streak!',
+        body: 'Keep it going — 5 concepts due.',
+      );
+
+      verify(() => mockPlugin.cancelAll()).called(1);
+      verify(() => mockPlugin.zonedSchedule(
+            id: 1,
+            title: '3-day streak!',
+            body: 'Keep it going — 5 concepts due.',
+            scheduledDate: any(named: 'scheduledDate'),
+            notificationDetails: any(named: 'notificationDetails'),
+            androidScheduleMode: any(named: 'androidScheduleMode'),
+            matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+          )).called(1);
+    });
+
+    test('scheduleReviewReminder only cancels when skipSchedule is true',
+        () async {
+      when(() => mockPlugin.cancelAll()).thenAnswer((_) async {});
+
+      await service.scheduleReviewReminder(
+        hour: 9,
+        skipSchedule: true,
+      );
+
+      verify(() => mockPlugin.cancelAll()).called(1);
+      verifyNever(() => mockPlugin.zonedSchedule(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            scheduledDate: any(named: 'scheduledDate'),
+            notificationDetails: any(named: 'notificationDetails'),
+            androidScheduleMode: any(named: 'androidScheduleMode'),
+            matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+          ));
+    });
+
+    test('scheduleReviewReminder uses provided title and body', () async {
+      when(() => mockPlugin.cancelAll()).thenAnswer((_) async {});
+      when(() => mockPlugin.zonedSchedule(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            scheduledDate: any(named: 'scheduledDate'),
+            notificationDetails: any(named: 'notificationDetails'),
+            androidScheduleMode: any(named: 'androidScheduleMode'),
+            matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+          )).thenAnswer((_) async {});
+
+      await service.scheduleReviewReminder(
+        hour: 9,
+        title: 'Welcome back!',
+        body: 'Quick review to refresh? 10 concepts waiting.',
+      );
+
+      verify(() => mockPlugin.zonedSchedule(
+            id: 1,
+            title: 'Welcome back!',
+            body: 'Quick review to refresh? 10 concepts waiting.',
+            scheduledDate: any(named: 'scheduledDate'),
+            notificationDetails: any(named: 'notificationDetails'),
+            androidScheduleMode: any(named: 'androidScheduleMode'),
+            matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+          )).called(1);
+    });
+  });
+}

--- a/test/storage/firestore_graph_repository_test.dart
+++ b/test/storage/firestore_graph_repository_test.dart
@@ -1,0 +1,153 @@
+import 'package:engram/src/models/concept.dart';
+import 'package:engram/src/models/document_metadata.dart';
+import 'package:engram/src/models/knowledge_graph.dart';
+import 'package:engram/src/models/quiz_item.dart';
+import 'package:engram/src/models/relationship.dart';
+import 'package:engram/src/storage/firestore_graph_repository.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late FakeFirebaseFirestore fakeFirestore;
+  late FirestoreGraphRepository repo;
+
+  setUp(() {
+    fakeFirestore = FakeFirebaseFirestore();
+    repo = FirestoreGraphRepository(
+      firestore: fakeFirestore,
+      userId: 'test-user',
+    );
+  });
+
+  KnowledgeGraph sampleGraph() {
+    return KnowledgeGraph(
+      concepts: const [
+        Concept(
+          id: 'c1',
+          name: 'Docker',
+          description: 'Container runtime',
+          sourceDocumentId: 'doc1',
+        ),
+        Concept(
+          id: 'c2',
+          name: 'Kubernetes',
+          description: 'Container orchestration',
+          sourceDocumentId: 'doc1',
+        ),
+      ],
+      relationships: const [
+        Relationship(
+          id: 'r1',
+          fromConceptId: 'c1',
+          toConceptId: 'c2',
+          label: 'used by',
+        ),
+      ],
+      quizItems: [
+        QuizItem.newCard(
+          id: 'q1',
+          conceptId: 'c1',
+          question: 'What is Docker?',
+          answer: 'A container runtime',
+        ),
+      ],
+      documentMetadata: const [
+        DocumentMetadata(
+          documentId: 'doc1',
+          title: 'Container Guide',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          ingestedAt: '2025-01-01T12:00:00.000Z',
+        ),
+      ],
+    );
+  }
+
+  group('FirestoreGraphRepository', () {
+    test('load returns empty graph when no data exists', () async {
+      final graph = await repo.load();
+      expect(graph.concepts, isEmpty);
+      expect(graph.relationships, isEmpty);
+      expect(graph.quizItems, isEmpty);
+      expect(graph.documentMetadata, isEmpty);
+    });
+
+    test('save and load round-trips', () async {
+      final graph = sampleGraph();
+      await repo.save(graph);
+
+      final loaded = await repo.load();
+      expect(loaded.concepts, hasLength(2));
+      expect(loaded.concepts.first.id, 'c1');
+      expect(loaded.relationships, hasLength(1));
+      expect(loaded.quizItems, hasLength(1));
+      expect(loaded.documentMetadata, hasLength(1));
+    });
+
+    test('save replaces existing data', () async {
+      // Save initial graph with 2 concepts
+      await repo.save(sampleGraph());
+
+      // Save smaller graph
+      const smallGraph = KnowledgeGraph(
+        concepts: [
+          Concept(
+            id: 'c3',
+            name: 'Helm',
+            description: 'Package manager',
+            sourceDocumentId: 'doc2',
+          ),
+        ],
+      );
+      await repo.save(smallGraph);
+
+      final loaded = await repo.load();
+      expect(loaded.concepts, hasLength(1));
+      expect(loaded.concepts.first.id, 'c3');
+      expect(loaded.relationships, isEmpty);
+    });
+
+    test('updateQuizItem writes single document', () async {
+      final graph = sampleGraph();
+      await repo.save(graph);
+
+      final updated = graph.quizItems.first.withReview(
+        easeFactor: 2.6,
+        interval: 1,
+        repetitions: 1,
+        nextReview: '2025-01-02T00:00:00.000Z',
+      );
+
+      await repo.updateQuizItem(graph.withUpdatedQuizItem(updated), updated);
+
+      final loaded = await repo.load();
+      expect(loaded.quizItems.first.repetitions, 1);
+      expect(loaded.quizItems.first.easeFactor, 2.6);
+      // Other data unchanged
+      expect(loaded.concepts, hasLength(2));
+    });
+
+    test('stores data under correct user path', () async {
+      await repo.save(sampleGraph());
+
+      // Verify the path structure: users/{userId}/data/graph/concepts/{id}
+      final conceptDoc = await fakeFirestore
+          .collection('users')
+          .doc('test-user')
+          .collection('data')
+          .doc('graph')
+          .collection('concepts')
+          .doc('c1')
+          .get();
+
+      expect(conceptDoc.exists, isTrue);
+      expect(conceptDoc.data()?['name'], 'Docker');
+    });
+
+    test('watch emits graph on load', () async {
+      await repo.save(sampleGraph());
+
+      final emitted = await repo.watch().first;
+      expect(emitted.concepts, hasLength(2));
+    });
+  });
+}

--- a/test/storage/graph_migrator_test.dart
+++ b/test/storage/graph_migrator_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:engram/src/models/concept.dart';
+import 'package:engram/src/models/knowledge_graph.dart';
+import 'package:engram/src/storage/firestore_graph_repository.dart';
+import 'package:engram/src/storage/graph_migrator.dart';
+import 'package:engram/src/storage/local_graph_repository.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GraphMigrator', () {
+    test('migrates local → Firestore', () async {
+      final tmpDir = Directory.systemTemp.createTempSync('engram_migrate_');
+      final local = LocalGraphRepository(dataDir: tmpDir.path);
+      final firestore = FirestoreGraphRepository(
+        firestore: FakeFirebaseFirestore(),
+        userId: 'test-user',
+      );
+
+      const graph = KnowledgeGraph(
+        concepts: [
+          Concept(
+            id: 'c1',
+            name: 'Docker',
+            description: 'Container runtime',
+            sourceDocumentId: 'doc1',
+          ),
+        ],
+      );
+      await local.save(graph);
+
+      final migrator = GraphMigrator(source: local, destination: firestore);
+      final result = await migrator.migrate();
+
+      expect(result.concepts, hasLength(1));
+
+      // Verify destination has the data
+      final loaded = await firestore.load();
+      expect(loaded.concepts, hasLength(1));
+      expect(loaded.concepts.first.id, 'c1');
+
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    test('skips migration for empty graph', () async {
+      final tmpDir = Directory.systemTemp.createTempSync('engram_migrate_');
+      final local = LocalGraphRepository(dataDir: tmpDir.path);
+      final firestore = FirestoreGraphRepository(
+        firestore: FakeFirebaseFirestore(),
+        userId: 'test-user',
+      );
+
+      final migrator = GraphMigrator(source: local, destination: firestore);
+      final result = await migrator.migrate();
+
+      expect(result.concepts, isEmpty);
+
+      tmpDir.deleteSync(recursive: true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Auth provider** (`auth_provider.dart`) — Firebase auth state as a Riverpod StreamProvider
- **Graph migrator** (`graph_migrator.dart`) — one-time migration from local JSON storage to Firestore
- **Test coverage** — 4 new test files: sync provider (421 lines), notification service (156 lines), Firestore repository (153 lines), graph migrator (62 lines)

Note: Several Phase 4 source files (`firestore_graph_repository.dart`, `sync_status.dart`, `sync_provider.dart`, `notification_provider.dart`, `notification_service.dart`) were already pulled into the Phase 3 PR as cross-phase dependencies. This PR adds the remaining new files and their tests.

## Test plan
- [x] All 162 tests pass locally (`flutter test`)
- [ ] CI passes on GitHub Actions
- [ ] Review: cage-match (Maxwell + Kelvin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)