### PR TITLE
Fix stale docstring on normalizeWikiUrl

### DIFF
--- a/lib/src/providers/friends_provider.dart
+++ b/lib/src/providers/friends_provider.dart
@@ -21,7 +21,7 @@ final socialRepositoryProvider = Provider<SocialRepository?>((ref) {
 });
 
 /// Normalizes a wiki URL for consistent hashing:
-/// lowercase, trim whitespace, remove trailing slash.
+/// trim whitespace, lowercase, strip trailing slashes, strip http(s) scheme.
 String normalizeWikiUrl(String url) {
   var normalized = url.trim().toLowerCase().replaceAll(RegExp(r'/+$'), '');
   normalized = normalized.replaceFirst(RegExp(r'^https?://'), '');


### PR DESCRIPTION
## Summary
- Update `normalizeWikiUrl` docstring to reflect scheme stripping added in #45

One-line comment fix caught in cage-match review.

## Test plan
- [x] Comment-only change, no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)