### PR TITLE
Extraction skill + FSRS migration ADR

### DIFF
--- a/.claude/skills/extracting-knowledge-graph/SKILL.md
+++ b/.claude/skills/extracting-knowledge-graph/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: extracting-knowledge-graph
+description: >
+  Extract a knowledge graph (concepts, relationships, quiz items) from wiki
+  documents or lecture notes. Use when the user asks to extract knowledge,
+  build a concept graph, create quiz cards, ingest documents, or improve
+  the extraction pipeline. Produces FSRS-ready quiz items with predicted
+  difficulty scores and dependency-aware concept relationships for spaced
+  repetition learning. See docs/FSRS_MIGRATION.md for the scheduling migration.
+---
+
+# Extracting Knowledge Graph
+
+## Purpose
+
+Transform unstructured wiki/document content into a structured knowledge graph consisting of **concepts**, **relationships**, and **quiz items** suitable for spaced repetition learning via SM-2.
+
+## When to Use
+
+- Ingesting documents from Outline wiki or other sources
+- Generating or refining extraction prompts for Claude API tool-use
+- Reviewing or improving extraction quality
+- Debugging why concepts/relationships/quiz items aren't extracting well
+- Adding new relationship types or quiz formats
+
+## Extraction Workflow
+
+### Phase 1: Document Preparation
+
+1. Receive document title and full text content
+2. Receive list of **existing concept IDs** already in the graph (for reuse, not duplication)
+3. Validate content is non-empty before proceeding
+
+### Phase 2: Knowledge Extraction via Claude API
+
+Use Claude with **forced tool calling** (`ToolChoice.tool`) on an `extract_knowledge` tool. The tool schema enforces structured output. See `references/extraction-schema.md` for the full schema.
+
+#### Extraction Rules
+
+**Concepts (3-10 per document depending on density):**
+- IDs must be **canonical lowercase kebab-case** (e.g., `docker-compose`, `sm2-algorithm`)
+- **REUSE existing concept IDs** when a concept already exists in the graph — this prevents duplicates across documents
+- Each concept gets: `id`, `name`, `description` (1-3 sentences), optional `tags`
+- Track `sourceDocumentId` to know which document produced each concept
+
+**Relationships:**
+- Only create relationships between concepts from **the current document**
+- Use `"depends on"` label for prerequisites; other labels for non-prerequisite connections
+- See `references/relationship-types.md` for the full relationship taxonomy
+- Each relationship: `id`, `fromConceptId`, `toConceptId`, `label`, optional `description`
+
+**Quiz Items (1-3 per concept):**
+- Clear, concise questions testing understanding of the concept
+- Answers should be **1-3 sentences** — not too short to be ambiguous, not too long to be a paragraph
+- Each item: `id`, `conceptId`, `question`, `answer`
+- Each item includes a **`predictedDifficulty`** score (1-10) — Claude's estimate of how hard this item is to learn. Used as FSRS initial D₀. See `references/scheduling-constraints.md`
+- SM-2 defaults are still applied at merge time for legacy compatibility, but FSRS uses the predicted difficulty
+
+### Phase 3: Validation
+
+After extraction, **before merging into the graph**:
+
+1. **Skip orphaned relationships** — if `fromConceptId` or `toConceptId` doesn't match any extracted concept, drop the relationship
+2. **Skip orphaned quiz items** — if `conceptId` doesn't match any extracted concept, drop the item
+3. Log what was skipped for debugging
+
+### Phase 4: Graph Merge
+
+1. If re-extracting a document, **remove all old concepts/relationships/quiz items** from that document first
+2. Add new concepts with `sourceDocumentId` set
+3. Add relationships (only if both endpoints exist in the full graph)
+4. Add quiz items (only if the concept exists)
+5. Update `DocumentMetadata` with collection info and `ingestedAt` timestamp
+
+#### Staggered Ingestion (for UI)
+
+When merging into a live graph with force-directed visualization:
+- Reveal concepts in **batches of 3**
+- **250ms delay** between batches
+- Allows the force-directed layout to settle without O(N^2) rebuilds
+- Save only the **final state** to storage (not each batch)
+
+## Quality Guidelines
+
+### Good Concept Examples
+
+| Document Content | Concept ID | Name | Why Good |
+|---|---|---|---|
+| "Docker Compose orchestrates multi-container apps" | `docker-compose` | Docker Compose | Kebab-case, canonical name |
+| "The SM-2 algorithm schedules reviews" | `sm2-algorithm` | SM-2 Algorithm | Reuses existing ID if already in graph |
+
+### Good Quiz Item Examples
+
+| Concept | Question | Answer | Why Good |
+|---|---|---|---|
+| `docker-compose` | What problem does Docker Compose solve? | Docker Compose orchestrates multi-container Docker applications, allowing you to define and run multiple services with a single configuration file. | Concise, tests understanding not memorization |
+| `sm2-algorithm` | How does SM-2 adjust the review interval after a failed response? | SM-2 resets the interval to 1 day and sets repetitions back to 0, while adjusting the ease factor downward based on the quality grade. | Tests mechanism, answer is precise |
+
+### Anti-Patterns to Avoid
+
+- **Overly granular concepts**: Don't create a concept for every paragraph. 3-10 per document.
+- **Trivial quiz items**: "What is X?" with answer "X is X." — test understanding, not definitions
+- **Cross-document relationships**: Only relate concepts extracted from the SAME document. Cross-document connections happen via concept ID reuse.
+- **Duplicate concepts**: Always check `existingConceptIds` before creating a new ID. If `kubernetes` already exists, reuse it.
+
+## Sub-Concept Splitting
+
+When a quiz card tests multiple distinct ideas, split the parent concept:
+
+1. Create **2-4 sub-concepts**, each covering a distinct aspect
+2. Sub-concept IDs **extend the parent** (e.g., `docker-compose` -> `docker-compose-services`, `docker-compose-networking`)
+3. Each sub-concept gets **1-2 focused quiz items**
+4. Sub-concepts should be independently understandable
+5. Set `parentConceptId` on each sub-concept
+
+## Iterating on Extraction Quality
+
+When extraction results are poor:
+
+1. **Check concept density** — too many concepts dilute quality, too few miss important ideas
+2. **Check relationship labels** — wrong labels break dependency-aware unlocking
+3. **Check quiz item specificity** — vague questions produce vague learning
+4. **Check ID reuse** — duplicate concepts fragment the graph
+5. **Review the system prompt** — small prompt changes can dramatically affect extraction quality
+
+## Difficulty Prediction Guidelines
+
+When extracting quiz items, Claude should predict difficulty (1-10) based on:
+
+| Factor | Low Difficulty (1-3) | Medium (4-6) | High Difficulty (7-10) |
+|---|---|---|---|
+| **Prerequisites** | None or 1 | 2-3 concepts needed | 4+ concepts needed |
+| **Abstraction** | Concrete, tangible | Mix of concrete/abstract | Purely abstract |
+| **Answer type** | Single fact recall | Explanation of mechanism | Synthesis across concepts |
+| **Information density** | 1 key point | 2-3 related points | Multiple interacting ideas |
+| **Confusion potential** | Unique concept | Some similar concepts exist | Easily confused with others |
+
+### Difficulty Prediction Examples
+
+| Question | Predicted Difficulty | Reasoning |
+|---|---|---|
+| "What file must every skill contain?" | 2 | Single fact, concrete, no prerequisites |
+| "How does progressive disclosure protect the context window?" | 5 | Requires understanding 2 concepts (skills + context window), explains a mechanism |
+| "Compare how skills, MCP, and sub-agents manage context window usage" | 8 | Synthesis across 3 concepts, abstract comparison, multiple interacting ideas |
+
+### Auto Sub-Concept Suggestion
+
+If predicted difficulty > 8, flag the quiz item for potential **sub-concept splitting**:
+- The question likely tests multiple distinct ideas
+- Each idea should become its own concept with difficulty 4-6
+- This prevents FSRS from scheduling a card that's inherently too hard to answer atomically
+
+## File References
+
+- `references/extraction-schema.md` — Full JSON schema for the `extract_knowledge` tool
+- `references/relationship-types.md` — Relationship type taxonomy and usage guidelines
+- `references/scheduling-constraints.md` — FSRS/SM-2 scheduling parameters and how they interact with extraction

--- a/.claude/skills/extracting-knowledge-graph/references/extraction-schema.md
+++ b/.claude/skills/extracting-knowledge-graph/references/extraction-schema.md
@@ -1,0 +1,188 @@
+# Extraction Tool Schema
+
+## Tool: `extract_knowledge`
+
+This is the Claude API tool definition used for structured extraction. Claude is forced to use this tool via `ToolChoice.tool`.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "required": ["concepts", "relationships", "quizItems"],
+  "properties": {
+    "concepts": {
+      "type": "array",
+      "description": "Key concepts found in the document (3-10 depending on density)",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "description"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Canonical lowercase kebab-case identifier (e.g., 'docker-compose'). REUSE existing IDs when the concept already exists in the graph."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable concept name"
+          },
+          "description": {
+            "type": "string",
+            "description": "1-3 sentence explanation of the concept"
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional categorization tags"
+          }
+        }
+      }
+    },
+    "relationships": {
+      "type": "array",
+      "description": "Relationships between concepts from THIS document only",
+      "items": {
+        "type": "object",
+        "required": ["id", "fromConceptId", "toConceptId", "label"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique relationship identifier"
+          },
+          "fromConceptId": {
+            "type": "string",
+            "description": "Source concept ID (must match a concept in this extraction)"
+          },
+          "toConceptId": {
+            "type": "string",
+            "description": "Target concept ID (must match a concept in this extraction or existing graph)"
+          },
+          "label": {
+            "type": "string",
+            "description": "Relationship type: 'depends on', 'is a type of', 'enables', 'related to'"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional explanation of the relationship"
+          }
+        }
+      }
+    },
+    "quizItems": {
+      "type": "array",
+      "description": "Quiz items for spaced repetition (1-3 per concept)",
+      "items": {
+        "type": "object",
+        "required": ["id", "conceptId", "question", "answer"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique quiz item identifier"
+          },
+          "conceptId": {
+            "type": "string",
+            "description": "Which concept this item tests (must match a concept ID)"
+          },
+          "question": {
+            "type": "string",
+            "description": "Clear question testing understanding of the concept"
+          },
+          "answer": {
+            "type": "string",
+            "description": "1-3 sentence answer"
+          },
+          "predictedDifficulty": {
+            "type": "number",
+            "description": "Claude's estimate of item difficulty (1-10). 1=pure recall of single fact, 5=explain a mechanism, 10=synthesize across many concepts. Used as FSRS initial D₀."
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Tool: `suggest_sub_concepts`
+
+Used when splitting a parent concept into sub-concepts.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "required": ["subConcepts"],
+  "properties": {
+    "subConcepts": {
+      "type": "array",
+      "description": "2-4 sub-concepts splitting the parent into distinct aspects",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "description", "quizItems"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Extends parent ID (e.g., 'docker-compose-services')"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable sub-concept name"
+          },
+          "description": {
+            "type": "string",
+            "description": "1-3 sentence explanation"
+          },
+          "quizItems": {
+            "type": "array",
+            "description": "1-2 focused quiz items per sub-concept",
+            "items": {
+              "type": "object",
+              "required": ["id", "question", "answer"],
+              "properties": {
+                "id": { "type": "string" },
+                "question": { "type": "string" },
+                "answer": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## System Prompt for Extraction
+
+```
+You are a knowledge extraction assistant. Given a document:
+
+- Extract 3-10 concepts depending on density
+- Concept IDs must be canonical lowercase kebab-case (e.g., "docker-compose")
+- REUSE existing concept IDs when they appear again (prevents duplicates)
+- Create relationships between concepts from THIS document only
+- Use "depends on" for prerequisites; other labels for non-prerequisite relationships
+- Create 1-3 quiz items per concept
+- Use clear, concise language; answers should be 1-3 sentences
+```
+
+## System Prompt for Sub-Concept Splitting
+
+```
+You are a concept decomposition assistant. Given a parent concept and its quiz item:
+
+- Split into 2-4 sub-concepts, each covering a distinct aspect
+- Each sub-concept should be independently understandable
+- Sub-concept IDs extend parent (e.g., "docker-compose" -> "docker-compose-services")
+- Create 1-2 quiz items per sub-concept
+- Use clear, concise language
+```
+
+## API Configuration
+
+| Parameter | Value |
+|---|---|
+| Model | `claude-sonnet-4-5-20250929` (configurable) |
+| Max tokens | 16,384 |
+| Tool choice | `ToolChoice.tool` (forced) |
+| Timeout | 3 minutes per document |

--- a/.claude/skills/extracting-knowledge-graph/references/relationship-types.md
+++ b/.claude/skills/extracting-knowledge-graph/references/relationship-types.md
@@ -1,0 +1,79 @@
+# Relationship Type Taxonomy
+
+## Core Relationship Types
+
+### `depends on` (Prerequisite)
+
+The most important relationship type. Drives **concept unlocking** — a concept cannot be unlocked for quiz sessions until all its prerequisites are mastered.
+
+**Use when:** Concept A cannot be understood without first understanding Concept B.
+
+**Direction:** `A --depends on--> B` means "A requires B"
+
+**Examples:**
+- `docker-compose --depends on--> docker-containers`
+- `sm2-ease-factor --depends on--> sm2-algorithm`
+- `react-hooks --depends on--> react-components`
+
+**Impact on learning:** The `GraphAnalyzer` performs topological sort on "depends on" edges. Concepts with no unsatisfied prerequisites are "unlocked" and eligible for quiz sessions. Getting this wrong breaks the learning order.
+
+### `is a type of` (Taxonomy)
+
+Hierarchical classification. Does NOT create a prerequisite — both can be learned independently.
+
+**Use when:** Concept A is a specific instance or subtype of Concept B.
+
+**Examples:**
+- `binary-search --is a type of--> search-algorithm`
+- `postgresql --is a type of--> relational-database`
+
+### `enables` (Capability)
+
+Concept A makes Concept B possible or practical. Weaker than "depends on" — B can be understood without A, but A makes B achievable.
+
+**Use when:** Learning A opens the door to doing B, but B's concept can be understood independently.
+
+**Examples:**
+- `docker-compose --enables--> microservice-deployment`
+- `ci-cd-pipeline --enables--> continuous-deployment`
+
+### `related to` (Association)
+
+General semantic connection. Use sparingly — it's the catch-all when no other type fits.
+
+**Use when:** Concepts are connected but none of the above types apply.
+
+**Examples:**
+- `kubernetes --related to--> docker-compose` (both orchestrate containers, but neither depends on the other)
+
+## Guidelines
+
+### Choosing the Right Type
+
+```
+Can A be understood without B?
+  NO  --> "depends on"
+  YES --> Is A a subtype of B?
+    YES --> "is a type of"
+    NO  --> Does A make B practically achievable?
+      YES --> "enables"
+      NO  --> "related to"
+```
+
+### Common Mistakes
+
+| Mistake | Why It's Wrong | Correct |
+|---|---|---|
+| Everything "related to" | Loses prerequisite information, breaks unlock order | Use "depends on" for real prerequisites |
+| Circular "depends on" | Creates cycles, breaks topological sort | Check that A truly can't exist without B |
+| Cross-document relationships | May reference concepts not yet extracted | Only relate concepts from the SAME document |
+| Reversed direction | `A depends on B` means A needs B, not B needs A | Think "A requires knowledge of B" |
+
+### Future: Typed Relationships (Issue #38)
+
+The current four types are intentionally simple. Issue #38 proposes expanding to include:
+- `analogy` — cross-discipline semantic connections
+- `contrast` — explicit differences between similar concepts
+- `composition` — part-of relationships
+
+These would enhance the mind map visualization and enable cross-discipline discovery.

--- a/.claude/skills/extracting-knowledge-graph/references/scheduling-constraints.md
+++ b/.claude/skills/extracting-knowledge-graph/references/scheduling-constraints.md
@@ -1,0 +1,130 @@
+# Scheduling Constraints (FSRS + SM-2 Legacy)
+
+## The Closed Loop: Extraction Informs Scheduling
+
+Unlike SM-2 (where scheduling state is applied AFTER extraction with no extraction-time input), **FSRS allows Claude to predict quiz item difficulty at extraction time**. This predicted difficulty becomes the initial D₀ for FSRS scheduling.
+
+```
+SM-2:  extraction → (question, answer) → fixed easeFactor=2.5  [DECOUPLED]
+FSRS:  extraction → (question, answer, difficulty) → informed D₀  [CLOSED LOOP]
+```
+
+## FSRS Core Variables
+
+| Variable | Meaning | Range |
+|---|---|---|
+| **Difficulty (D)** | Inherent complexity of the card | 1-10 |
+| **Stability (S)** | Days for retrievability to drop from 100% to 90% | 0+ days |
+| **Retrievability (R)** | Probability of successful recall right now | 0-1 |
+
+### Difficulty at Extraction Time
+
+Claude predicts `predictedDifficulty` (1-10) based on:
+- Number of prerequisite concepts needed
+- Abstract vs concrete nature
+- Whether answer requires recall, explanation, or synthesis
+- Information density of the answer
+- Confusion potential with similar concepts
+
+This prediction becomes FSRS's initial D₀. FSRS then adjusts via mean reversion after each review:
+
+```
+D′(D,G) = w₇ · D₀(3) + (1 - w₇) · (D - w₆ · (G - 3))
+```
+
+**Mean reversion prevents "ease hell"** — even wrong predictions self-correct.
+
+### Desired Retention by Graph Position
+
+FSRS allows per-concept `desired_retention` (target recall probability):
+
+| Graph Position | Desired Retention | Reasoning |
+|---|---|---|
+| Hub concepts (many dependents) | 0.95 | Forgetting blocks downstream concepts |
+| Standard concepts | 0.90 | Default FSRS target |
+| Leaf concepts (no dependents) | 0.85 | Nothing downstream is blocked |
+| Guardian-protected concepts | 0.97 | Game mechanic: guardians keep clusters strong |
+
+This replaces the crude `1.5x interval` repair mission multiplier with principled retention targets.
+
+## SM-2 Legacy (cards without predicted difficulty)
+
+Existing cards with `difficulty == null` use SM-2 scheduling until migrated:
+
+### New Card Defaults (SM-2)
+
+```
+easeFactor: 2.5    # Fixed starting difficulty
+interval: 0        # Due immediately
+repetitions: 0     # No successful reviews yet
+nextReview: now()  # Due immediately upon creation
+lastReview: null   # Never reviewed
+```
+
+### SM-2 Quality Grades (0-5)
+
+| Grade | Meaning |
+|---|---|
+| 0 | Complete blackout |
+| 1 | Incorrect, but recognized on reveal |
+| 2 | Incorrect, but answer felt easy |
+| 3 | Correct with serious difficulty |
+| 4 | Correct with some hesitation |
+| 5 | Perfect response |
+
+### SM-2 Scheduling
+
+- **Failed (quality < 3):** interval=1, repetitions=0, ease factor adjusted down
+- **Passed (quality >= 3):** repetitions++, interval progression: 1→6→round(interval*EF)
+- **Ease factor update:** `newEF = oldEF + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02))`, min 1.3
+
+### FSRS Rating Scale (4 grades)
+
+| Rating | Meaning |
+|---|---|
+| Again | Failed to recall |
+| Hard | Recalled with significant difficulty |
+| Good | Recalled with some effort |
+| Easy | Recalled effortlessly |
+
+Note: Quiz screen UI must be updated when migrating from SM-2 (0-5 scale) to FSRS (4-grade scale).
+
+## Why Extraction Quality Matters for Scheduling
+
+### Too easy → wasted reviews (both algorithms)
+- SM-2: ease factor climbs, intervals grow fast, item drifts away
+- FSRS: low difficulty + high ratings → stability grows naturally (correct behavior)
+
+### Too hard → frustration (SM-2 is worse)
+- SM-2: ease factor drops to 1.3, stuck in daily review forever ("ease hell")
+- FSRS: mean reversion prevents death spiral, card adapts over time
+
+### Right level → lasting knowledge (FSRS is better calibrated)
+- SM-2: all cards start equal, no way to know difficulty until first review
+- FSRS: Claude's difficulty prediction means first interval already accounts for complexity
+
+### Auto sub-concept suggestion
+- If `predictedDifficulty > 8`, flag for splitting — the card likely tests multiple ideas
+- Each sub-concept should have difficulty 4-6 after splitting
+
+## Concept Unlocking and Dependencies
+
+The `GraphAnalyzer` uses "depends on" relationships to determine unlock order. **This is orthogonal to scheduling** — unlocking rules stay the same regardless of SM-2 vs FSRS:
+
+1. Concepts with NO incoming "depends on" edges are **foundational** (always unlocked)
+2. A concept is unlocked when ALL its prerequisites have at least one quiz item with `repetitions >= 1` (SM-2) or `stability > 0` (FSRS equivalent)
+3. Unlocking is **graph-wide** (not scoped by collection)
+4. Quiz session item selection CAN be scoped by collection
+
+### Impact on extraction:
+- Every concept must have at least 1 quiz item to enable the unlock chain
+- If `A depends on B` but B has no quiz items, A can never be unlocked
+- "depends on" chains increase predicted difficulty for downstream concepts
+
+## Retrievability as Mastery Signal
+
+FSRS provides retrievability (R) as a continuous 0-1 value — much richer than SM-2's binary "has been reviewed" signal. This improves:
+
+- **Mind map mastery colors**: R maps directly to grey→red→amber→green gradient
+- **Network health scoring**: `NetworkHealthScorer` can use R instead of heuristic mastery
+- **Team mastery snapshots**: Per-concept R values are more granular than SM-2's repetition count

--- a/docs/FSRS_MIGRATION.md
+++ b/docs/FSRS_MIGRATION.md
@@ -1,0 +1,189 @@
+# FSRS Migration: Closing the Extraction↔Scheduling Loop
+
+## Origin Story
+
+This insight emerged during a Feb 15 2026 session where we:
+1. Ingested an 11-video Anthropic course on Agent Skills into Outline wiki
+2. Created an `extracting-knowledge-graph` skill in `.claude/skills/` — encoding Engram's extraction workflow as a portable, progressively-disclosed skill
+3. Noticed a comment in the skill: "SM-2 scheduling state is applied AFTER extraction because Claude has no knowledge of SM-2 when extracting"
+4. Asked: **what if we used FSRS instead?**
+
+That question broke open something fundamental.
+
+## The SM-2 Wall
+
+With SM-2, every new quiz card starts identically:
+- `easeFactor: 2.5`
+- `interval: 0`
+- `repetitions: 0`
+
+There is nothing Claude can contribute at extraction time because the initial state is a constant. The extraction service and the scheduling engine are **completely decoupled** — not by design choice, but because SM-2 provides no mechanism for coupling them.
+
+The extraction service produces `(question, answer)`. The scheduler wraps it in `(question, answer, easeFactor=2.5, interval=0, repetitions=0)`. Claude's understanding of the content's difficulty, complexity, and pedagogical weight is discarded.
+
+## FSRS Breaks the Wall
+
+FSRS (Free Spaced Repetition Scheduler) operates on three memory variables:
+
+- **Difficulty (D)**: Inherent complexity of the card (1-10). Affects how fast stability grows after review.
+- **Stability (S)**: Time in days for retrievability to drop from 100% to 90%.
+- **Retrievability (R)**: Probability of successful recall at a given moment.
+
+The critical insight: **Difficulty is a property of the card, not the learner's history.**
+
+In standard FSRS, initial difficulty is determined by the first rating: `D₀(G) = w₄ - (G-3) · w₅`. But Claude already has the information needed to predict that difficulty at extraction time:
+
+- How many prerequisite concepts the answer depends on
+- Whether the concept is abstract or concrete
+- Whether the answer requires synthesis vs recall
+- How information-dense the answer is
+- How similar the concept is to commonly confused ones
+
+### The Closed Loop
+
+Instead of extracting `(question, answer)`, Claude extracts `(question, answer, predicted_difficulty)`.
+
+```
+BEFORE (SM-2):
+  Extraction → (question, answer) → Fixed scheduling state
+  Claude's understanding of difficulty: DISCARDED
+
+AFTER (FSRS):
+  Extraction → (question, answer, difficulty) → Informed scheduling state
+  Claude's understanding of difficulty: PRESERVED AND USED
+```
+
+This means **the extraction skill we built teaches Claude not just how to extract knowledge, but how to predict how hard that knowledge is to learn.** The scheduler trusts those predictions. The loop is closed.
+
+## Desired Retention by Graph Position
+
+FSRS introduces `desired_retention` — the target probability of recall when a card is scheduled. This is a knob SM-2 doesn't have.
+
+Combined with our dependency-aware knowledge graph, we can set desired retention per-concept based on structural importance:
+
+| Graph Position | Desired Retention | Reasoning |
+|---|---|---|
+| **Hub concepts** (many dependents) | 0.95 | Forgetting a hub blocks many downstream concepts |
+| **Standard concepts** | 0.90 | Default FSRS target |
+| **Leaf concepts** (no dependents) | 0.85 | Lower stakes — nothing downstream is blocked |
+| **Guardian-protected concepts** | 0.97 | Game mechanic: guardians ensure their cluster stays strong |
+| **Repair mission targets** | Temporarily elevated | Currently 1.5x interval hack; `desired_retention` is more principled |
+
+This replaces the crude `1.5x interval` multiplier for repair missions with a first-principles approach: instead of hacking the interval, tell the scheduler what retention level you actually want.
+
+## Mean Reversion: Solving Ease Hell
+
+SM-2's `easeFactor` can drop to 1.3 and stay there permanently — the infamous "ease hell" where cards get stuck in daily review cycles with no escape.
+
+FSRS prevents this with mean reversion in the difficulty update:
+
+```
+D′(D,G) = w₇ · D₀(3) + (1 - w₇) · (D - w₆ · (G - 3))
+```
+
+This pulls difficulty toward a midpoint after each review. Even if Claude's initial difficulty prediction is wrong, FSRS self-corrects without trapping the learner.
+
+## Impact on Extraction Quality
+
+### Quiz Items That Are Too Easy (SM-2)
+- Users always rate 5 → ease factor climbs → intervals grow fast → item barely reviewed
+- **Problem**: Trivial questions don't build lasting knowledge
+- **SM-2 response**: Nothing. The card just drifts away.
+
+### Quiz Items That Are Too Easy (FSRS)
+- Low initial difficulty + high ratings → stability grows naturally
+- **FSRS response**: Card is scheduled further out, which is correct behavior
+- **But**: If Claude predicted high difficulty and user rates it easy, mean reversion adjusts. Self-correcting.
+
+### Quiz Items That Are Too Hard (SM-2)
+- Users always rate 0-2 → ease factor drops to 1.3 → interval stuck at 1 day → frustrating
+- **Problem**: "Ease hell" — no escape without manual intervention
+- **User must**: Split into sub-concepts or reset the card manually
+
+### Quiz Items That Are Too Hard (FSRS)
+- High initial difficulty + low ratings → stability grows slowly but consistently
+- **FSRS response**: Mean reversion prevents death spiral. The card adapts.
+- **And**: Claude's predicted difficulty can trigger automatic sub-concept suggestions at extraction time: "This concept has predicted difficulty 9/10 — consider splitting"
+
+## The Recursive Insight
+
+This migration emerged from a session where we:
+1. Ingested a course about agent skills into Outline
+2. Built an extraction skill for Engram (a skill about how to extract knowledge)
+3. Realized the skill could be improved by the scheduling algorithm it references
+4. Discovered that FSRS closes a loop that SM-2 couldn't
+
+**Engram is a tool that learns from wikis. We used it to ingest a course about skills. That course taught us to build a skill that makes Engram's extraction better. And the skill revealed that the scheduling algorithm should change — which in turn changes the skill itself.**
+
+The tool is learning how to learn, and we're learning alongside it.
+
+## Dart Package
+
+[`fsrs` on pub.dev](https://pub.dev/packages/fsrs) — pure Dart, v2.0.1, 160/160 pub points, MIT license.
+
+- 21 model weights (FSRS-6)
+- Configurable `desired_retention` (0-1)
+- Configurable learning steps
+- No native dependencies — pure Dart
+
+Alternative: [`fsrs-rs-dart`](https://github.com/open-spaced-repetition/fsrs-rs-dart) — Rust implementation with Flutter bindings via `flutter_rust_bridge`. Higher performance but adds native dependency.
+
+**Recommendation**: Start with pure Dart `fsrs` package. Migrate to Rust bindings only if performance becomes an issue (unlikely for quiz scheduling).
+
+## Migration Plan
+
+### Phase 1: Add FSRS alongside SM-2 (non-breaking)
+
+1. **Add `fsrs` package** to pubspec.yaml
+2. **Add `difficulty` field to `QuizItem`** (nullable, defaults to null for existing cards)
+3. **Update extraction tool schema** — add `predictedDifficulty` (1-10) to quiz item output
+4. **Update extraction system prompt** — add difficulty prediction guidelines
+5. **Update extraction skill** — rename `references/sm2-constraints.md` to `references/scheduling-constraints.md`, add FSRS content
+6. **Write FSRS engine** — pure function mirroring SM-2 pattern, consuming `fsrs` package
+7. **Tests**: Existing SM-2 tests continue passing; new FSRS tests for difficulty-informed scheduling
+
+### Phase 2: Dual-mode scheduling
+
+1. **Scheduler selects engine** based on card state:
+   - Cards with `difficulty != null` → FSRS engine
+   - Cards with `difficulty == null` (legacy) → SM-2 engine (or migrate with `difficulty = 5.0` default)
+2. **Quiz screen rating**: SM-2 uses 0-5; FSRS uses Again/Hard/Good/Easy (4 grades). Need rating UI update.
+3. **Desired retention provider** — computes per-concept retention based on graph position
+4. **Update mastery visualization** — FSRS retrievability (0-1) maps more naturally to mastery colors than SM-2's binary "mastered/not" heuristic
+
+### Phase 3: Full FSRS (deprecate SM-2)
+
+1. **Migrate all legacy cards** — set `difficulty = 5.0` (neutral midpoint), convert SM-2 state to FSRS state
+2. **Remove SM-2 engine** and related code
+3. **Update cooperative game mechanics** — replace `1.5x interval` hack with `desired_retention` adjustments
+4. **Update challenge quiz item snapshots** — strip FSRS scheduling fields (same security concern as #30)
+
+### Phase 4: Extraction-informed scheduling (the closed loop)
+
+1. **Claude predicts difficulty at extraction time** — added to tool schema in Phase 1, now used by scheduler
+2. **Difficulty prediction evaluation** — compare Claude's predicted D₀ with actual D after 5+ reviews per card
+3. **Feedback loop** — if predictions are consistently off, adjust extraction prompt (or retrain with review data)
+4. **Auto sub-concept suggestion** — if predicted difficulty > 8, suggest splitting at extraction time
+
+## Interactions with Other Planned Work
+
+| Feature | Impact |
+|---|---|
+| **#38 Typed relationships** | Relationship types inform difficulty prediction — "depends on" chains increase predicted difficulty |
+| **#39 Concept embeddings** | Embedding similarity could predict confusion-based difficulty (similar concepts = harder to distinguish) |
+| **#40 Local-first Drift/SQLite** | FSRS state is more complex than SM-2 — schema design should account for D, S, R fields |
+| **#41 CRDT sync** | FSRS card state (D, S, R) needs CRDT treatment — LWW-Register per field with `lastReview` as timestamp |
+| **Guardian system** | `desired_retention` per cluster replaces crude interval multipliers |
+| **Network health** | Retrievability (R) is a better input to `NetworkHealthScorer` than SM-2's binary mastery |
+
+## Decision
+
+**Migrate from SM-2 to FSRS.** The closed extraction↔scheduling loop is the primary motivation, but ease-hell prevention, per-concept desired retention, and principled game mechanic integration are strong secondary reasons. The pure Dart `fsrs` package makes this a clean replacement.
+
+## References
+
+- [FSRS Algorithm](https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm)
+- [ABC of FSRS](https://github.com/open-spaced-repetition/fsrs4anki/wiki/abc-of-fsrs)
+- [dart-fsrs package](https://pub.dev/packages/fsrs)
+- [FSRS GitHub](https://github.com/open-spaced-repetition/free-spaced-repetition-scheduler)
+- [Anthropic Agent Skills course](https://kb.xdeca.com/collection/agent-skills-with-anthropic-3wNTu43J6m) — ingested into Outline, catalyst for this investigation


### PR DESCRIPTION
## Summary

- **Extraction skill** (`.claude/skills/extracting-knowledge-graph/`) — Encodes the full knowledge graph extraction workflow as a portable agent skill with progressive disclosure. Includes SKILL.md, tool schemas, relationship type taxonomy, and FSRS-aware scheduling constraints with difficulty prediction guidelines.
- **FSRS migration ADR** (`docs/FSRS_MIGRATION.md`) — Documents the decision to migrate from SM-2 to FSRS. Key insight: FSRS's Difficulty parameter is a property of the card (not the learner), so Claude can predict it at extraction time — closing the extraction↔scheduling loop that SM-2 forced open. 4-phase migration plan included.
- **CLAUDE.md updates** — New ADR reference, FSRS investigation section, reshuffled roadmap (FSRS Phase 1 now next-up), completed items (extraction skill, Outline wiki migration, Agent Skills course ingestion).

### The Recursive Insight

This work emerged from ingesting an Anthropic course on Agent Skills into the Outline wiki. Building a skill to encode Engram's extraction workflow revealed that SM-2 forces a wall between extraction and scheduling (every card starts at easeFactor=2.5, Claude's understanding of difficulty is discarded). FSRS dissolves that wall — Claude predicts difficulty at extraction time, FSRS uses it as initial D₀. The tool that learns from wikis learned how to learn better.

## Test plan
- [x] All 427 tests pass (`flutter test`)
- [x] No Dart code changed — docs and skills only
- [ ] Verify skill is detected by Claude Code (`/skills` command after restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)