### PR TITLE
Circle initial placement + pre-settle for clean graph appearance

### DIFF
--- a/lib/src/engine/force_directed_layout.dart
+++ b/lib/src/engine/force_directed_layout.dart
@@ -193,21 +193,32 @@ class ForceDirectedLayout {
     _velocities = List<Offset>.filled(nodeCount, Offset.zero);
   }
 
-  /// Build initial positions, using [initial] where non-null and filling the
-  /// rest with random offsets. Note: pre-seeded entries skip RNG calls, so the
-  /// random sequence for later nodes diverges from a cold-start layout. This is
-  /// intentional — strict seed-determinism only matters for the null case
-  /// (first build / tests).
+  /// Build initial positions, using [initial] where non-null and placing new
+  /// nodes evenly on a circle centered in the canvas. This gives a clean
+  /// starting animation — nodes spread outward along edges rather than
+  /// scrambling from random positions.
   List<Offset> _initPositions(int? seed, List<Offset?>? initial) {
-    final rng = math.Random(seed);
-    const margin = 30.0;
+    final center = Offset(width / 2, height / 2);
+    final radius = 0.2 * math.min(width, height);
+
+    // Count new nodes so they can be distributed evenly on the circle.
+    var newCount = 0;
+    for (var i = 0; i < nodeCount; i++) {
+      final provided =
+          (initial != null && i < initial.length) ? initial[i] : null;
+      if (provided == null) newCount++;
+    }
+
+    var newIndex = 0;
     return List.generate(nodeCount, (i) {
       final provided =
           (initial != null && i < initial.length) ? initial[i] : null;
       if (provided != null) return provided;
+      final angle = (2 * math.pi * newIndex) / math.max(newCount, 1);
+      newIndex++;
       return Offset(
-        margin + rng.nextDouble() * (width - 2 * margin),
-        margin + rng.nextDouble() * (height - 2 * margin),
+        center.dx + radius * math.cos(angle),
+        center.dy + radius * math.sin(angle),
       );
     });
   }

--- a/lib/src/ui/graph/force_directed_graph_widget.dart
+++ b/lib/src/ui/graph/force_directed_graph_widget.dart
@@ -280,6 +280,12 @@ class _ForceDirectedGraphWidgetState extends State<ForceDirectedGraphWidget>
       pinnedNodes: pinnedIndices.isNotEmpty ? pinnedIndices : null,
     );
 
+    // Pre-settle: run ~1 second of simulation (60 steps at 60fps) before the
+    // first paint so nodes are already spread out when they appear.
+    for (var i = 0; i < 60; i++) {
+      if (!_layout.step()) break;
+    }
+
     _syncPositions();
   }
 


### PR DESCRIPTION
## Summary
- New nodes start evenly spaced on a circle at the canvas center (radius = 20% of smaller dimension) instead of random positions
- Widget pre-runs 60 simulation steps (~1s at 60fps) before first paint so nodes appear already spread out
- Updated widget contract tests to account for pre-settle cooling steps

## Test plan
- [x] All 498 tests pass (`flutter test`)
- [x] Analyzer clean (`dart analyze`)
- [x] Visual verification: graph appears pre-settled on load, nodes bloom outward cleanly

Generated with [Claude Code](https://claude.com/claude-code)