### PR TITLE
Filter ingest graph to show only session concepts

### DIFF
--- a/lib/src/models/ingest_state.dart
+++ b/lib/src/models/ingest_state.dart
@@ -15,6 +15,7 @@ class IngestState {
     this.currentDocumentTitle = '',
     this.statusMessage = '',
     this.errorMessage = '',
+    this.sessionConceptIds = const {},
   });
 
   final IngestPhase phase;
@@ -27,6 +28,10 @@ class IngestState {
   final String currentDocumentTitle;
   final String statusMessage;
   final String errorMessage;
+
+  /// Concept IDs extracted during this ingestion session. Used to filter the
+  /// live graph visualization to only show newly extracted nodes.
+  final Set<String> sessionConceptIds;
 
   double get progress =>
       totalDocuments > 0 ? processedDocuments / totalDocuments : 0;
@@ -42,6 +47,7 @@ class IngestState {
     String? currentDocumentTitle,
     String? statusMessage,
     String? errorMessage,
+    Set<String>? sessionConceptIds,
   }) {
     return IngestState(
       phase: phase ?? this.phase,
@@ -56,6 +62,7 @@ class IngestState {
       currentDocumentTitle: currentDocumentTitle ?? this.currentDocumentTitle,
       statusMessage: statusMessage ?? this.statusMessage,
       errorMessage: errorMessage ?? this.errorMessage,
+      sessionConceptIds: sessionConceptIds ?? this.sessionConceptIds,
     );
   }
 }

--- a/lib/src/providers/ingest_provider.dart
+++ b/lib/src/providers/ingest_provider.dart
@@ -48,6 +48,7 @@ class IngestNotifier extends Notifier<IngestState> {
       extractedCount: 0,
       skippedCount: 0,
       processedDocuments: 0,
+      sessionConceptIds: {},
     );
 
     try {
@@ -151,9 +152,15 @@ class IngestNotifier extends Notifier<IngestState> {
             '${result.relationships.length} relationships, '
             '${result.quizItems.length} quiz items');
 
-        // Merge into graph — staggered for live knowledge graph animation
+        // Merge into graph — staggered for live knowledge graph animation.
+        // Register session concept IDs first so the live graph filter can
+        // show nodes as they appear during staggered ingestion.
         state = state.copyWith(
           statusMessage: 'Adding ${result.concepts.length} concepts...',
+          sessionConceptIds: {
+            ...state.sessionConceptIds,
+            ...result.concepts.map((c) => c.id),
+          },
         );
         debugPrint('[Ingest] Adding concepts to graph...');
         try {

--- a/lib/src/ui/screens/ingest_screen.dart
+++ b/lib/src/ui/screens/ingest_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../models/ingest_state.dart';
+import '../../models/knowledge_graph.dart';
 import '../../providers/ingest_provider.dart';
 import '../../providers/knowledge_graph_provider.dart';
 import '../../providers/settings_provider.dart';
@@ -140,7 +141,22 @@ class _ProgressView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final graph = ref.watch(knowledgeGraphProvider).valueOrNull;
+    final fullGraph = ref.watch(knowledgeGraphProvider).valueOrNull;
+    final sessionIds = state.sessionConceptIds;
+
+    // Filter to only show concepts extracted in this session.
+    final graph = fullGraph != null && sessionIds.isNotEmpty
+        ? KnowledgeGraph(
+            concepts: fullGraph.concepts
+                .where((c) => sessionIds.contains(c.id))
+                .toList(),
+            relationships: fullGraph.relationships
+                .where((r) =>
+                    sessionIds.contains(r.fromConceptId) &&
+                    sessionIds.contains(r.toConceptId))
+                .toList(),
+          )
+        : null;
 
     return Column(
       children: [


### PR DESCRIPTION
## Summary
- Ingest progress view was showing the entire knowledge graph — now filters to only session concepts
- Added `sessionConceptIds` to `IngestState`, populated before staggered merge so nodes appear as they arrive
- Relationships filtered to edges where both endpoints are session concepts

## Test plan
- [x] All 498 tests pass
- [x] Analyzer clean
- [x] Visual: re-extract shows only newly extracted concepts growing in real-time

Generated with [Claude Code](https://claude.com/claude-code)