### PR TITLE
fix: use clockProvider for remaining DateTime.now() calls

### DIFF
--- a/lib/src/ui/screens/friends_screen.dart
+++ b/lib/src/ui/screens/friends_screen.dart
@@ -10,6 +10,7 @@ import '../../models/team_goal.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/catastrophe_provider.dart';
 import '../../providers/challenge_provider.dart';
+import '../../providers/clock_provider.dart';
 import '../../providers/friends_provider.dart';
 import '../../providers/glory_board_provider.dart';
 import '../../providers/guardian_provider.dart';
@@ -235,7 +236,7 @@ class _FriendsTab extends ConsumerWidget {
                 message: messageController.text.isEmpty
                     ? null
                     : messageController.text,
-                createdAt: DateTime.now().toUtc().toIso8601String(),
+                createdAt: ref.read(clockProvider)().toIso8601String(),
               );
 
               await ref.read(nudgeProvider.notifier).sendNudge(nudge);
@@ -462,13 +463,14 @@ class _TeamTab extends ConsumerWidget {
 
   Future<void> _showScheduleStormDialog(BuildContext context, WidgetRef ref) async {
     // Default: start 24 hours from now
-    final defaultStart = DateTime.now().toUtc().add(const Duration(hours: 24));
+    final now = ref.read(clockProvider)();
+    final defaultStart = now.add(const Duration(hours: 24));
 
     final date = await showDatePicker(
       context: context,
       initialDate: defaultStart,
-      firstDate: DateTime.now(),
-      lastDate: DateTime.now().add(const Duration(days: 30)),
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 30)),
     );
     if (date == null || !context.mounted) return;
 
@@ -549,8 +551,8 @@ class _TeamTab extends ConsumerWidget {
             FilledButton(
               onPressed: () async {
                 if (titleController.text.isEmpty) return;
-                final deadline = DateTime.now()
-                    .toUtc()
+                final deadline = ref
+                    .read(clockProvider)()
                     .add(const Duration(days: 7))
                     .toIso8601String();
                 await ref.read(teamGoalsProvider.notifier).createGoal(

--- a/lib/src/ui/screens/settings_screen.dart
+++ b/lib/src/ui/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/auth_provider.dart';
+import '../../providers/clock_provider.dart';
 import '../../providers/notification_provider.dart';
 import '../../providers/settings_provider.dart';
 
@@ -203,7 +204,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     if (timestamp == null) return 'Never synced';
     final date = DateTime.tryParse(timestamp);
     if (date == null) return 'Never synced';
-    final diff = DateTime.now().toUtc().difference(date);
+    final diff = ref.read(clockProvider)().difference(date);
     if (diff.inMinutes < 1) return 'Last synced: just now';
     if (diff.inHours < 1) return 'Last synced: ${diff.inMinutes}m ago';
     if (diff.inDays < 1) return 'Last synced: ${diff.inHours}h ago';

--- a/lib/src/ui/widgets/challenge_dialog.dart
+++ b/lib/src/ui/widgets/challenge_dialog.dart
@@ -7,6 +7,7 @@ import '../../models/concept.dart';
 import '../../models/friend.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/challenge_provider.dart';
+import '../../providers/clock_provider.dart';
 import '../../providers/knowledge_graph_provider.dart';
 import '../../providers/user_profile_provider.dart';
 
@@ -136,7 +137,7 @@ class _ChallengeDialogState extends ConsumerState<ChallengeDialog> {
         toUid: widget.friend.uid,
         quizItemSnapshot: quizItem.toJson(),
         conceptName: _selectedConcept!.name,
-        createdAt: DateTime.now().toUtc().toIso8601String(),
+        createdAt: ref.read(clockProvider)().toIso8601String(),
       );
 
       await ref.read(challengeProvider.notifier).sendChallenge(challenge);


### PR DESCRIPTION
## Summary
- Replace raw `DateTime.now()` in UI widgets/screens with `ref.read(clockProvider)()`
- Covers challenge creation, nudge creation, goal deadlines, storm scheduling, and sync timestamp display
- Providers were already migrated; this completes the UI-layer half

Closes #47

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test` — all 538 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)