### PR TITLE
fix: preserve team node positions across graph rebuilds (#61)

### DIFF
--- a/lib/src/ui/graph/force_directed_graph_widget.dart
+++ b/lib/src/ui/graph/force_directed_graph_widget.dart
@@ -203,6 +203,9 @@ class _ForceDirectedGraphWidgetState extends State<ForceDirectedGraphWidget>
     for (final node in _nodes) {
       oldPositions[node.id] = node.position;
     }
+    for (final teamNode in widget.teamNodes) {
+      oldPositions[teamNode.id] = teamNode.position;
+    }
 
     final graph = widget.graph;
     final analyzer = GraphAnalyzer(graph);
@@ -277,12 +280,14 @@ class _ForceDirectedGraphWidgetState extends State<ForceDirectedGraphWidget>
     final totalCount = _nodes.length + teamNodes.length;
     final initialPositions = List<Offset?>.generate(totalCount, (i) {
       if (i < _nodes.length) return oldPositions[_nodes[i].id];
-      return null; // team nodes get fresh positions — see #61
+      return oldPositions[teamNodes[i - _nodes.length].id];
     });
     final hasOldPositions = initialPositions.any((p) => p != null);
     final pinnedIndices = <int>{
       for (var i = 0; i < _nodes.length; i++)
         if (oldPositions.containsKey(_nodes[i].id)) i,
+      for (var i = 0; i < teamNodes.length; i++)
+        if (oldPositions.containsKey(teamNodes[i].id)) _teamNodeStartIndex + i,
     };
 
     // Scale layout area with node count so large graphs have room to breathe.

--- a/test/ui/graph/team_graph_overlay_test.dart
+++ b/test/ui/graph/team_graph_overlay_test.dart
@@ -66,6 +66,104 @@ void main() {
       expect(find.byType(CustomPaint), findsWidgets);
     });
 
+    testWidgets('team node positions preserved across graph rebuild',
+        (tester) async {
+      final graph1 = KnowledgeGraph(
+        concepts: [
+          Concept(
+              id: 'c1',
+              name: 'Docker',
+              description: 'Containers',
+              sourceDocumentId: 'doc1'),
+          Concept(
+              id: 'c2',
+              name: 'K8s',
+              description: 'Orchestration',
+              sourceDocumentId: 'doc1'),
+        ],
+        relationships: [
+          const Relationship(
+              id: 'r1',
+              fromConceptId: 'c2',
+              toConceptId: 'c1',
+              label: 'depends on'),
+        ],
+        quizItems: [
+          QuizItem.newCard(
+              id: 'q1', conceptId: 'c1', question: 'Q?', answer: 'A.'),
+        ],
+      );
+
+      // Same team node instance persists across rebuilds (like in production).
+      final teamNodes = [
+        TeamNode(
+          friend: const Friend(uid: 'u1', displayName: 'Alice'),
+          detailedSnapshot: const DetailedMasterySnapshot(
+            summary: MasterySnapshot(totalConcepts: 2, mastered: 1),
+            conceptMastery: {'c1': 'mastered'},
+          ),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ForceDirectedGraphWidget(
+              graph: graph1,
+              teamNodes: teamNodes,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Set a known position on the team node (simulates a settled layout).
+      // _buildGraph will read this via widget.teamNodes when the graph changes.
+      const knownPosition = Offset(350, 250);
+      teamNodes.first.position = knownPosition;
+
+      // Add a new concept to trigger _buildGraph via didUpdateWidget.
+      final graph2 = KnowledgeGraph(
+        concepts: [
+          ...graph1.concepts,
+          Concept(
+              id: 'c3',
+              name: 'Helm',
+              description: 'Package manager',
+              sourceDocumentId: 'doc1'),
+        ],
+        relationships: [
+          ...graph1.relationships,
+          const Relationship(
+              id: 'r2',
+              fromConceptId: 'c3',
+              toConceptId: 'c2',
+              label: 'depends on'),
+        ],
+        quizItems: graph1.quizItems.toList(),
+      );
+
+      // Re-pump with updated graph — triggers didUpdateWidget → _buildGraph.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ForceDirectedGraphWidget(
+              graph: graph2,
+              teamNodes: teamNodes,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Team node should be pinned at its old position.
+      expect(
+        (teamNodes.first.position - knownPosition).distance,
+        lessThan(1.0),
+        reason: 'Team node should stay pinned across graph rebuild',
+      );
+    });
+
     testWidgets('renders without team nodes (backward compatible)',
         (tester) async {
       final graph = KnowledgeGraph(


### PR DESCRIPTION
## Summary
- Save team node positions in `oldPositions` map during `_buildGraph` rebuilds
- Look up team positions when seeding the new layout (replaces `return null`)
- Pin persisting team nodes as immovable anchors during re-settle
- Add test verifying team node position preservation across graph rebuilds

Closes #61

## Test plan
- [x] New test: team node positions preserved across graph rebuild
- [x] All 577 existing tests pass, no regressions
- [x] `dart analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)