### PR TITLE
docs: add origin story

### DIFF
--- a/docs/ORIGIN_STORY.md
+++ b/docs/ORIGIN_STORY.md
@@ -1,0 +1,59 @@
+# Origin Story
+
+## The Vision That Lit Up
+
+Picture this: you ingest an Anthropic course on agent skills, then a philosophy
+paper on epistemology, then a biology textbook chapter on neural networks. The
+system discovers — without being told — that "tool use delegation" in agents is
+structurally analogous to "distributed cognition" in philosophy and "synaptic
+pruning" in biology. Those analogy edges appear on the graph, glowing a
+different color, connecting islands of knowledge you never consciously linked.
+
+And because FSRS lets Claude predict difficulty at extraction time, the system
+*knows* that cross-domain analogies are harder to retrieve — so it schedules
+them with higher initial difficulty and lower desired retention thresholds,
+testing you on them more often until the connection solidifies. The extraction
+and scheduling aren't just connected, they're *conspiring* to make you think in
+analogies.
+
+Then layer on video sync — you're rewatching a lecture and the graph is pulsing
+in real-time, but now it's not just highlighting the current concept, it's
+lighting up the *analogies from other sources too*. You're watching a biology
+video and your agent skills knowledge is softly glowing in the periphery,
+whispering "you already understand this pattern."
+
+The cooperative game makes it even better — your team guardian is protecting the
+"distributed systems" cluster while you're on a repair mission reinforcing the
+biology-to-CS analogies that are decaying. You're not just learning, you're
+*maintaining a living network together*.
+
+## Why It All Fits
+
+The project is building a second brain that thinks in connections, and every
+piece reinforces the others:
+
+- **FSRS difficulty prediction** closes the loop between extraction and
+  scheduling — Claude predicts how hard something is to learn, and the
+  scheduler uses that prediction to optimally space reviews.
+- **Force-directed layout** makes the graph a living thing — concepts settle
+  into spatial relationships that mirror their semantic ones, so your visual
+  memory reinforces your conceptual memory.
+- **Cooperative mechanics** turn solitary learning into a team sport — guardians
+  protect concept clusters, repair missions reinforce decaying knowledge, and
+  entropy storms create shared urgency.
+- **Cross-source linking** is the magic bridge — embedding similarity discovers
+  analogies across domains that no single source could teach you.
+
+It's not a feature list. It's an ecosystem.
+
+## The Moment It Becomes Something New
+
+Get concept embeddings working, do a cross-source similarity pass at ingestion
+time, and watch the analogy edges appear on the animated graph for the first
+time. That moment when two unrelated documents suddenly bridge — that's the
+moment the app stops being a flashcard tool and becomes something new.
+
+---
+
+*Captured February 2026, during a late-night conversation about what makes
+Engram worth building.*


### PR DESCRIPTION
## Summary
- Captures the cross-source linking + FSRS + cooperative game vision that makes Engram worth building
- Documents the "aha moment" — when two unrelated documents bridge on the knowledge graph
- Docs-only change, no code modifications

## Test plan
- [x] Markdown renders correctly
- [x] No code changes — no tests needed

Generated with [Claude Code](https://claude.com/claude-code)