### PR TITLE
docs: the Diamond Age direction — Engram becomes the Book

### DIFF
--- a/docs/DIAMOND_AGE_PRIMER.md
+++ b/docs/DIAMOND_AGE_PRIMER.md
@@ -1,0 +1,81 @@
+# The Diamond Age Direction — Engram becomes the Book
+
+**Decision (Nick, 2026-06-11):** flashcards are removed as Engram's learning
+surface. Engram becomes the Young Lady's Illustrated Primer: **beautiful
+illustrated stories that teach difficult concepts**, with the learner as
+protagonist, followed by warm Socratic dialogue instead of quiz items. The
+knowledge graph and FSRS remain — as the book's hidden spine, deciding *which
+story the book tells today*.
+
+> "Flash cards are shit — the primer is the way to learn things."
+
+## What teaching looks like
+
+1. **The book opens on a story.** A generated, illustrated, narrated story
+   that teaches the concepts due for review or sitting in a detected gap.
+   The learner is the protagonist; the story is built from what the book
+   knows about them.
+2. **The margin darkens.** After the story, a short Socratic trial — the
+   two-register pattern proven in the CLI primer (`nickmeinhold/primer`):
+   a warm teacher voice and a cold-but-fair examiner voice, with the
+   kind-challenge rule (the instant the learner wobbles, all sternness
+   drops; the arc "I feel dumb → oh, I see it" is the learning event).
+3. **The spine updates.** Trial verdicts become FSRS ratings; mastery moves;
+   the living graph glows; tomorrow's story is chosen accordingly.
+
+**The story is the review.** Spaced repetition survives — only the *surface*
+changes, from cards to narrative + dialogue.
+
+## Why this is mostly an upgrade, not a rebuild
+
+Engram already has the story spine and doesn't know it:
+
+| Already shipped | Becomes |
+| --- | --- |
+| Narration pipeline (`narration_service.dart`: Claude writes a concept-annotated script → ElevenLabs synthesizes with character timestamps → time-aligned concept markers) | The **storybook engine**. Script generation upgrades from "narrate these concepts" to story-shaped: beats, stakes, protagonist framing. Concept markers already align highlights to audio; **per-beat illustrations swap on the same timestamps.** |
+| `QuizItem` per-concept FSRS state | Unchanged — but rated by trial verdicts, not card self-grades (struggled→again, passed→good, final-gate→easy) |
+| `GapAnalyzer` + `RecommendationService` | The book's editorial voice: which story needs telling |
+| `SessionMode` / quiz session state | A **dialogue session** over the concepts FSRS+gaps selected |
+| `extraction_service.dart` (Claude tool-use) | The same pattern drives the two dialogue minds in Dart |
+| ElevenLabs client | The book's voices (the CLI primer uses two distinct voices — teacher/examiner — to signal register change; keep that) |
+
+## What's genuinely new
+
+- **Story-shaped script generation.** The craft is already worked out in the
+  CLI primer's books — see the `## story` sections in
+  `nickmeinhold/primer/books/` and the `.primer.md` authored from
+  `ai-mathematician-demo` ("you once tore a theorem out of a textbook on
+  purpose…"). Protagonist framing is the active ingredient.
+- **Illustrations.** Per-beat image generation. The hard requirement is
+  **style consistency across beats** — one visual voice per book, not
+  twenty unrelated good images. This is the first design question to
+  settle (model choice, style anchoring, character consistency).
+- **The dialogue minds in Dart.** Port the *system-prompt craft*, not the
+  Python: `primer.py`'s `primer_system`/`kernel_system` templates, the
+  SUMMON / TRIAL COMPLETE / NOTE LEARNER / AMEND BOOK token protocol, and
+  the kind-challenge rules verbatim. Mic input in Flutter is an open
+  question (speech_to_text plugin vs whisper).
+- **The learner file.** A living cross-subject profile (which pictures land,
+  pace, trip-wires, what restores them) read by both minds and updated from
+  margin notes each session — Nell's book knew Nell. Reference
+  implementation: `learner.md` + `[NOTE LEARNER: …]` in the CLI primer.
+
+## Relationship to the CLI primer
+
+`nickmeinhold/primer` stays alive as **the pedagogy lab**: prompt-craft
+iterates there in minutes (it's ~600 lines of Python over headless Claude)
+and proven patterns port into Engram. The data contract between the two —
+companion knowledge graphs in Engram's schema and FSRS-ready review events —
+is specified in [PRIMER_BRIDGE.md](PRIMER_BRIDGE.md).
+
+## Sequence
+
+1. Ingest the bridge files (graphs + review events) — proves the spine moves
+   from external dialogue sessions. ([PRIMER_BRIDGE.md](PRIMER_BRIDGE.md))
+2. Story mode v1: story-shaped narration scripts + per-beat illustrations on
+   the existing timestamp alignment. No dialogue yet — the book *reads to
+   you* beautifully first.
+3. Dialogue sessions replace quiz sessions: two minds, trials, verdicts →
+   FSRS. Flashcard UI retires.
+4. The editorial loop: FSRS + GapAnalyzer choose the day's story; the
+   learner file personalizes it.

--- a/docs/PRIMER_BRIDGE.md
+++ b/docs/PRIMER_BRIDGE.md
@@ -1,0 +1,84 @@
+# The Primer Bridge — data contract with `nickmeinhold/primer`
+
+The CLI primer (the pedagogy lab) and Engram (the memory) share **data, not
+code**. Two file formats, both produced by the primer today; Engram's side is
+ingest (open task). All field names match Engram's own serialization
+(`Concept.toJson` / `Relationship.toJson` / FSRS rating vocabulary) so ingest
+is parsing, not translation.
+
+## 1. Companion knowledge graphs — `<book>.graph.json`
+
+Emitted by `primer graph` (and automatically by `primer new`) next to each
+book. Example: `books/containers-and-comonads.graph.json` in the primer repo
+(25 concepts, 36 relationships, generated 2026-06-11).
+
+```json
+{
+  "concepts": [
+    {
+      "id": "container",
+      "name": "Container",
+      "description": "A data structure described by two questions: …",
+      "sourceDocumentId": "containers-and-comonads.md",
+      "tags": ["waypoint:1"]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "container--prerequisite--container-morphism",
+      "fromConceptId": "container",
+      "toConceptId": "container-morphism",
+      "label": "must be understood before",
+      "type": "prerequisite"
+    }
+  ]
+}
+```
+
+- `type` is a `RelationshipType.name` (camelCase): `prerequisite`,
+  `generalization`, `composition`, `enables`, `analogy`, `contrast`,
+  `relatedTo`. The primer filters anything else out before writing.
+- Every concept carries a `waypoint:N` tag binding it to the book's teaching
+  road. **The waypoint tag is the whole bridge**: prose pedagogy and graph
+  state reference each other through this one string.
+- `sourceDocumentId` is the book filename — a book is a document source,
+  ingestible the way wiki documents are.
+
+## 2. Review events — `review_events.jsonl`
+
+Appended by the primer's reading loop whenever the examiner mind (the Kernel)
+delivers a trial verdict. One JSON object per line:
+
+```json
+{"ts": "2026-06-11T13:26:56.621959+00:00",
+ "conceptId": "container",
+ "rating": "good",
+ "source": "primer-trial",
+ "book": "Containers, Comonads, and Trust"}
+```
+
+- Rating mapping, fixed in the primer:
+  - trial verdict `struggled` → `again`
+  - trial verdict `passed` → `good`
+  - final gate `[KERNEL ACCEPTS]` → `easy` (all waypoints)
+- Events fan out to every concept tagged with the waypoints in the trial's
+  scope.
+- Location: `~/git/individuals/nickmeinhold/primer/review_events.jsonl`
+  (gitignored there — it is learner-private state; Engram ingests and owns it).
+
+## Engram-side ingest (to build)
+
+1. Import a `.graph.json` as a document source (the `ingest_document` /
+   `ingest_state` models fit): concepts and relationships merge by id —
+   the primer's slugs are stable across regenerations of the same book.
+2. Apply review events to each concept's `QuizItem` FSRS state in timestamp
+   order, using the standard fsrs rating for `again`/`good`/`easy`.
+3. Idempotency: `(ts, conceptId)` pairs are unique; keep a high-water mark.
+
+## The return path (later)
+
+Once ingest exists, the primer asks Engram-side state "what is due, what is
+weak, where are the gaps" and opens the book at that node — FSRS-scheduled
+*conversational* review. In the Diamond Age direction
+([DIAMOND_AGE_PRIMER.md](DIAMOND_AGE_PRIMER.md)) the same query chooses
+which story the book tells today.


### PR DESCRIPTION
Captures tonight's product decision: flashcards retire; Engram becomes the illustrated Primer (stories + Socratic trials on the FSRS/graph spine). Two docs:

- **DIAMOND_AGE_PRIMER.md** — the vision, the shipped-vs-new mapping (the narration pipeline is already the storybook engine), and the build sequence.
- **PRIMER_BRIDGE.md** — the data contract with `nickmeinhold/primer` (companion graphs in Engram's exact schema, FSRS-ready review events, rating mapping).

Tasks #3/#4/#5 in claude-tasks hold the build briefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)