### PR TITLE
feat(fsrs): add optional rubric to quiz items (#670 step 1)

### DIFF
--- a/docs/crucible/dialogue-sessions/CRUCIBLE.md
+++ b/docs/crucible/dialogue-sessions/CRUCIBLE.md
@@ -1,0 +1,40 @@
+# CRUCIBLE — Dialogue Sessions (replace flashcards with primer-style Socratic dialogue)
+
+**Ore selected:** #670 — replace Engram's flashcard quiz with primer-style two-mind Socratic dialogue.
+**Date:** 2026-07-09 · **Forge:** /crucible · **Status:** hot-phase (pre-temper)
+
+## The pick, and why it glows
+
+Engram's learning surface today is a flashcard deck: `QuizPhase.idle → question → revealed → summary`, rate Again/Hard/Good/Easy. It *works*, but it is the generic SRS interaction every competitor has. Nick's product call (2026-06-11): **"replace engram's flash cards with what the primer does."**
+
+This session found **two independent, complete reference implementations** of the target pedagogy that *agree on the road*:
+
+1. **`primer.py`** (Nick's own, `~/git/individuals/nickmeinhold/primer/`) — an 894-line Diamond-Age engine: a warm PRIMER mind (teacher) + a KERNEL mind (examiner), a token wire-protocol (`[SUMMON KERNEL]` / `[TRIAL COMPLETE: passed|struggled]` / `[KERNEL ACCEPTS]` / `[THE BOOK RESTS]`), a cross-topic `learner.md` distilled from `[NOTE LEARNER]` margin notes, and it **already emits Engram-schema `graph.json` + `review_events.jsonl`** (the #669 bridge).
+2. **`nagisanzenin/engram`** (independent, MIT) — a generation-first 8-beat dialogue grammar, a **blind assessor** (grader deliberately isolated from the tutoring dialogue), confidence integrity (same-breath / null-if-declined / never-invented), an anti-sycophancy oath with citations, and a curriculum-architect node schema carrying `probe` + `rubric` + `arbitrary`/`threshold`.
+
+## The synthesis finding (the load-bearing idea)
+
+**They are not competitors — they are the two halves of Engram's own loop.**
+- `primer.py` = the **ENCODE** surface: warm, tell-first, learner-as-protagonist, story-shaped → this is #671 (illustrated story mode).
+- `nagisanzenin` = the **RETRIEVE** surface: generation-first, blind-graded, calibration-honest → this is #670 proper (the flashcard replacement).
+
+Design consequence: **warm in encode/story, disciplined in review/retrieve.** One rule holds in *both*: never resolve before a commitment; never invent a grade or a confidence number.
+
+## Why it matters (impact, not affect)
+
+- Removes a real thing: the rote flashcard loop, replaced by a tutor that teaches like a mind. Directly serves the "mind-blowing for Mary" activation bar (`concept_engram_activation_gap`).
+- Unblocks #671 (story mode shares the two-mind + learner-model spine) and completes #669 (the primer data bridge already exists).
+- Feeds the existing FSRS Phase-4 calibration loop a second signal (learner confidence) it currently can't capture.
+
+## The falsifier (fired 2026-07-09, against real source — SURVIVED)
+
+**Claim that could be slag:** *"Extraction already emits a grading rubric + leak-free probe, so the tutor/assessor are not blocked on a schema gap — the whole build is just a chat UI."*
+
+**Verification:** `extraction_service.dart:122` requires `['id','conceptId','question','answer']` (+ optional `predictedDifficulty`). **No `rubric`, no `arbitrary`/`threshold`, no confidence capture in `QuizSessionState.ratings` (List<int>).** The blind assessor's grading contract genuinely does not exist. **Ore is real.**
+
+## Remaining open variables (not yet resolved — for Cast/Temper to close)
+
+- `[OPEN]` Voice/STT in-app: text-only v1, or mic (speech_to_text vs whisper)? (primer is voice; Flutter mic is an open question per #670.)
+- `[OPEN]` Does the blind assessor run per-node (latency ×N) or batched at session end (context-loss risk)?
+- `[OPEN]` Default warmth level for the review surface — how cold is too cold for Mary?
+- `[OPEN]` Cost/latency of a two-LLM dialogue turn vs a static flashcard (managed-AI tier economics, task #6).

--- a/docs/crucible/dialogue-sessions/DESIGN.md
+++ b/docs/crucible/dialogue-sessions/DESIGN.md
@@ -1,0 +1,74 @@
+# DESIGN — Dialogue Sessions (#670)
+
+Cast-phase mold. What to build, in what order, with what tradeoffs. Grounded in `RESEARCH.md`.
+
+## Problem
+
+Engram's learning surface is a generic flashcard deck (`QuizPhase.idle→question→revealed→summary`). It doesn't teach — it tests recall of a canned answer. The product goal (#670, #671, activation gap) is a **tutor that teaches like a mind**: generation-first, honestly graded, and that *learns the learner*. Two reference implementations exist and agree; the schema to support them does not yet.
+
+## Shape
+
+Three layers, each independently useful. The invariant across all: **never resolve before commitment; never invent a grade or confidence.**
+
+### Layer A — the grading contract (schema)
+Additive fields, no migration break (both models already tolerate missing fields via `fromJson`):
+- **`QuizItem.rubric: List<String>?`** — 2-4 grading criteria ("names both terms", "explains why normalization is needed"). The blind assessor's contract.
+- **`QuizItem.arbitrary: bool` (default false)** — non-derivable content (terminology, brute facts) → mnemonic path, skip derivation theater.
+- **`QuizItem.threshold: bool` (default false)** — portal concept → extra scaffolding / an artifact.
+- Extraction tool schema (`extraction_service.dart`) gains `rubric` (required, 2-4 strings) + optional `arbitrary`/`threshold` on both the main and sub-concept `quizItems` schemas. Prompt gains: "the `question` is a free-recall probe — it must NOT contain or leak the answer."
+- `toJson`/`fromJson`/`toContentSnapshot` updated; `rubric` omitted-when-null for back-compat.
+
+### Layer B — the dialogue engine (pure, testable, no UI)
+- **`DialogueTutor`** — wraps an `anthropic_sdk_dart` streaming call with the generation-first system prompt (ported from nagisanzenin's `dialogue-grammar.md`, warmth-dialed by surface). Emits control tokens parsed by the **existing `parseConceptMarkers`** infra (extended with a small token grammar: `[VERIFY]`, `[PRODUCTION]…[/PRODUCTION]`, `[NOTE_LEARNER:]`).
+- **`BlindAssessor`** — a *separate* `anthropic_sdk_dart` call that receives only `{claim, rubric, probe, production, confidence}` (never the dialogue) and returns strict receipt JSON `{grade, rating, misconceptions, rubric_notes, feedback_line}`. Grade→rating maps to the existing Again/Hard/Good/Easy → `withFsrsReview`.
+- **`DialogueProduction`** — the learner's committed answer + confidence (`int?`, null-if-declined), persisted to Drift **the moment it exists** (context-loss safety), before grading.
+- **`LearnerProfile`** — cross-topic profile (the `learner.md` analogue), distilled at session close from `[NOTE_LEARNER]` observations. Stored locally (Drift), read at session start. **This is the "learns you" thesis made concrete.**
+
+### Layer C — the UI (replace the flashcard screen)
+- New `DialogueSessionState` (replaces/extends `QuizSessionState`): a turn list, current production, phase (`greeting→encoding→verifying→grading→closing`), pending-grade queue.
+- `DialogueScreen` — chat-style turns; the tutor streams, the learner commits a production + a gut 0-100 confidence in the same field, the verdict returns as a feedback line. Text-first v1 (no mic).
+- FSRS wiring unchanged: a graded production → `withFsrsReview` → existing scheduler. Confidence stored as the second calibration signal alongside `predictedDifficulty`.
+
+## Build order (core-first, each step ships value alone)
+
+1. **Layer A schema** — `rubric`/`arbitrary`/`threshold` on model + extraction + tests. *Ships value alone:* richer extraction, backfillable, unblocks everything. **Start here (the falsified critical path).**
+2. **`BlindAssessor` (pure)** — grade a `{production, rubric, probe, claim, confidence}` → receipt JSON, mapped to FSRS rating. Unit-tested against fixtures. *Ships alone:* a better grader even for the *existing* flashcard reveal (grade free-text instead of self-rated Again/Hard/Good/Easy).
+3. **`DialogueTutor` + token grammar** — generation-first single-node loop, control tokens via extended `parseConceptMarkers`. *Ships alone:* a "dialogue mode" toggle on one concept.
+4. **`DialogueSessionState` + `DialogueScreen`** — full session over FSRS-due/gap concepts. Replaces `quiz_screen` behind a setting flag.
+5. **`LearnerProfile` + margin notes** — personalization layer; distill at close. *Ships alone:* "it remembers how you learn."
+6. **(Later / #671)** story-shaped encode surface reusing Layer B; **(Later)** mic/STT.
+
+## Tradeoffs taken (named, with owner)
+
+- **Two-LLM turns cost more than a flashcard flip.** Owner: gates on task #6 (managed-AI economics). *Mitigation:* text-first, batch the assessor at session end (not per-node) in v1, measure cost per session before enabling for managed-tier users. BYOK users bear their own cost.
+- **Blind assessor adds latency** (extra call). *Mitigation:* batch at session close; grade optimistically-async so the dialogue never blocks on grading.
+- **Warmth vs rigor is surface-dependent, not global.** Accepted: review surface is disciplined (Mary may find it "harder" than a flashcard), story surface is warm. *Mitigation:* the one universal rule (no resolve-before-commit, no invented grade) keeps warmth honest.
+- **`QuizSessionState` isn't deleted day one** — dialogue lives behind a flag until proven. Accepted debt: two session paths briefly coexist.
+
+## Blast-radius & consent spine (cage before monster)
+
+- **No new public endpoint / no attacker-controlled agent spawn.** The tutor/assessor are called with the *user's own* content + their own API key (BYOK) or the managed tier (already quota-gated by task #6). Blast-radius owner = the same per-user quota infra #6 builds.
+- **Injection surface:** learner productions + ingested document text are untrusted. They enter the API as structured message content, never string-concatenated into a system prompt. The assessor grades only the learner's verbatim production, treating tutor bracket-notes as context, never as the learner's words (nagisanzenin's rule, ported).
+- **Cost blast-radius:** a runaway dialogue loop burns tokens. *Mitigation:* per-session turn cap + mode budget (Sprint/Standard/Deep), same as nagisanzenin's mode caps.
+- **Data:** productions persist to Drift (local-first); no new cloud surface. FSRS state changes go through the existing `withFsrsReview` door.
+
+## Claims to falsify (for the adversary at Temper)
+
+1. **The two-LLM turn is affordable enough to ship** even to managed-tier users, OR text-first + batched-assessor keeps it viable. *(Could be wrong: cost may force BYOK-only, shrinking the activation win.)*
+2. **A blind assessor grading free-text is more trustworthy than learner self-rating** — and doesn't just move the inflation problem into the rubric quality. *(Could be wrong: a bad rubric grades worse than an honest human self-rate.)*
+3. **Reusing `parseConceptMarkers` for tutor control-tokens is sound** — the narration marker grammar extends cleanly to dialogue control without collision. *(Could be wrong: streaming partial tokens mid-word may break parsing.)*
+4. **Warmth-in-encode / rigor-in-retrieve is the right split** and doesn't just confuse Mary with two personalities. *(Could be wrong: consistency may matter more than optimality.)*
+5. **This is higher-impact than shipping the activation-gap trio (#296/#297/#298) first.** *(Could be wrong: a beautiful tutor with no first-run content still leaves Mary at an empty graph — sequencing risk.)*
+
+## Rejected alternatives
+
+- **Just bolt a chat UI onto the existing flashcard** — rejected: no grading contract, so it's a chatbot that can't drive FSRS honestly (the whole point).
+- **Persona-in-one-prompt (tutor + grader same call)** — rejected: destroys separation of powers; the grader is influenced by rapport, inflating the schedule.
+- **Port `primer.py` wholesale** — rejected: primer is the *encode/story* surface (warm, tell-first); #670 is the *retrieve* surface (generation-first). Wrong half. primer is the seed for #671.
+- **Voice-first v1** — rejected for v1: STT is an unresolved design axis; text-first ships the pedagogy without blocking on mic/whisper.
+
+## Open variables (not silently resolved)
+
+- `[CONFIRM]` v1 = text-only (recommended), mic deferred? 
+- `[CONFIRM]` assessor batched-at-close (recommended) vs per-node?
+- `[CONFIRM]` sequencing vs the activation trio (#296-298) — which ships first? (Claim-to-falsify #5.)

--- a/docs/crucible/dialogue-sessions/RESEARCH.md
+++ b/docs/crucible/dialogue-sessions/RESEARCH.md
@@ -1,0 +1,66 @@
+# RESEARCH — Dialogue Sessions
+
+Heat-phase findings. Grounded in the **real** engram source (read 2026-07-09), the two reference implementations, and the learning-science citations the references carry.
+
+## 1. Engram's real substrate (verified, not from CLAUDE.md)
+
+| Artifact | State today | Relevance |
+|---|---|---|
+| `extraction_service.dart:117-144` | `quizItems` schema: `required [id, conceptId, question, answer]` + optional `predictedDifficulty` (1-10, FSRS D₀ seed) | **No `rubric`, no `arbitrary`/`threshold`.** The schema gap. |
+| `models/quiz_item.dart` | `QuizItem`: id, conceptId, question, answer, full FSRS state (interval, nextReview, difficulty, stability, fsrsState, lapses, `predictedDifficulty` write-once, `reviewCount`). `toJson`/`fromJson` auto-migrate. `toContentSnapshot()` for challenges. | `question`=probe, `answer`=canonical claim. Missing: `rubric`, classification flags. Additive change. |
+| `models/quiz_session_state.dart` | `QuizPhase{idle,question,revealed,summary}`, `IList<QuizItem> items`, `ratings` as `IList<int>` (r≥3 = correct). | The flashcard state machine #670 replaces. `ratings` has **no confidence, no per-node production text.** |
+| `engine/concept_marker_parser.dart:33` | `parseConceptMarkers(annotatedText)` → `MarkerParseResult` (used by narration) | **Reusable** for parsing tutor control-tokens from an LLM stream. |
+| `services/extraction_service.dart` | Uses `anthropic_sdk_dart` `Tool.custom` with forced tool-use; `defaultExtractionModel='claude-sonnet-4-5'`. | The pattern to follow for tutor + assessor API calls. |
+| FSRS | `withFsrsReview`, `predictedDifficulty` + `reviewCount` + `evaluatePredictions()` (Phase 4). Ratings map to fsrs Again/Hard/Good/Easy. | Grade→rating→FSRS path exists. Confidence would be a **new** second calibration signal alongside `predictedDifficulty`. |
+
+## 2. The two reference implementations — mechanism diff
+
+| Dimension | `primer.py` (ENCODE) | `nagisanzenin` (RETRIEVE) |
+|---|---|---|
+| Core loop | TELL-first in morsels; ends turn with an **invitation, not a quiz** | GENERATION-first 8 beats: gap→predict→struggle(hint ladder)→resolve→self-explain→connect→verify→close. **Never resolve before commitment.** |
+| Examiner | KERNEL: a second Mind (Haiku), in-fiction character, warm when learner falters | **Blind assessor**: separate agent, sees only `{claim, rubric, probe, production, confidence}`, never the lesson. Returns receipt JSON. |
+| Separation of powers | Soft (Kernel converses, can be warmed) | **Hard** (grader cannot be influenced by rapport — anti-inflation) |
+| Confidence | none | Same-breath ask; **null if declined; never invented.** High-confidence errors = hypercorrection treasure. |
+| Anti-sycophancy | "warm, a little playful, never twee" | Explicit oath w/ citations (below) |
+| Learner model | **`learner.md`** cross-topic profile, distilled from `[NOTE LEARNER]` margin notes at session close | per-topic `model` (interests, strategy_weights, challenge_band) |
+| Wire protocol | Text tokens (`[SUMMON KERNEL:]` etc.) parsed from stream | Shell state via `engram.py` (`stash add`→assessor→`receipt`→`stash clear`) |
+| Node schema | book map (waypoints, pictures, alternates) | `claim`, `probe` (leak-free), `rubric` (2-4 criteria), `transfer_probe`, `arbitrary`, `threshold`, edges |
+| Safety | — | **learner text never on a shell command line** (injection); **stash the moment a production exists** (context-loss safety) |
+
+## 3. Learning-science citations (carried by nagisanzenin's grammar; worth honoring)
+
+- **Testing/retrieval effect** — retrieval practice beats re-exposure for retention → the generation-first discipline for the RETRIEVE surface.
+- **Pretesting effect** — a wrong guess *before* learning improves what sticks.
+- Controlling praise nets **negative** on adult intrinsic motivation (Deci/Koestner/Ryan 1999, d=−0.78) → "encouragement is information, never pressure."
+- Sympathy reads as a low-ability cue (Graham 1984; Brummelman 2014) → "absolve, never pity" after a lapse.
+- Over-helpful tutor harms retention once removed (Bastani 2025) → warmth is *the same withheld help, kindly framed*, not more help.
+- "Teach relevance, don't preach it" (Canning & Harackiewicz 2015) → elicit the goal-link, don't lecture it.
+- Hypercorrection — high-confidence errors, once corrected, are unusually durable → spotlight + re-derive + log misconception.
+
+## 4. Prior art / constraints for the Flutter port
+
+- **Two-LLM turn cost**: each dialogue turn is ≥1 tutor call; grading adds an assessor call (batchable). Materially more expensive than a static flashcard flip → gates on task #6 (managed-AI tier / cost caps). Measure before committing to per-node grading.
+- **STT in Flutter**: `speech_to_text` plugin (on-device, free, lower accuracy) vs whisper (heavier). Text-first v1 sidesteps this entirely.
+- **Streaming**: `anthropic_sdk_dart` supports streaming; the marker-parser already handles incremental text → tutor control-tokens can be parsed live.
+- **Context-loss safety**: nagisanzenin's "stash productions immediately" maps to persisting the learner's production to Drift *before* grading — aligns with Engram's local-first/CRDT posture.
+- **Injection**: learner productions + document text are untrusted; in Flutter they go into the API as structured content (lower risk than a shell), but the tutor's output drives FSRS state, so the assessor must grade only the learner's actual words, never tutor-inserted bracket notes.
+
+## 5. LLM-grading literature (searched 2026-07-09) — validates the temper, hands us knobs
+
+**The exact combo (LLM-graded free recall → SRS scheduling) is a LIVE 2025-26 frontier, mostly "work in progress":**
+- **LECTOR** (arXiv 2508.03275, Aug 2025) — LLM semantic-similarity assessment wired into spaced-repetition scheduling. Closest published analogue to #670.
+- **ASEE WIP** — *Enhancing Active Recall and Spaced Repetition with LLM-Augmented Review Systems* — LLM grading of recall feeding the scheduler.
+
+**Automated short-answer grading (ASAG) is mature — consensus = AI-HUMAN HYBRID, not full-auto:**
+- LLMarking (ACM L@S 2025); EvalCouncil (committee-and-chief + human adjudication). Recurring conclusion: "reliability limited by instability + bias; human oversight required; hybrid optimizes." → **confirms human-override + monitor, deflates the elaborate shadow-mode.** (Nick's push was right.)
+- Clinical short-answer calibration (PMC12896245): rubric-based LLM grading viable but needs SME adjudication on ambiguous cases.
+
+**LLM-as-judge bias is well-studied — names the failure mode + gives design knobs:**
+- **Leniency is prompt-driven + systematic:** a detailed/structured rubric prompt scores HARSHER; a minimal prompt scores MORE LENIENT — same answer. → the grading prompt is a calibration knob; **version it, fix it, never tweak casually** (arXiv 2506.22316).
+- **Grading scale:** human-LLM alignment HIGHEST on a **0-5 scale** (arXiv 2601.03444). Engram's 4-point Again/Hard/Good/Easy is close — revisit before locking.
+- **Mid-range degradation:** LLM graders agree with humans at the EXTREMES, degrade on PARTIAL answers — exactly the `Hard`↔`Good` boundary FSRS is most sensitive to. → **point human-override at the mushy middle, not everywhere** (arXiv 2605.07647).
+- **Verbalized confidence is poorly calibrated;** sampling-consistency calibrates better (arXiv 2602.00279). → deflates the "ask for a gut 0-100" confidence idea; if kept, prefer consistency-across-samples over a self-reported number.
+
+**The GAP Engram can own:** nearly all ASAG grades answers for a *grade* (assessment). Almost nobody grades free recall to drive a *schedule* and then measures **downstream retention** (only ~1 AI-pretesting retention study, arXiv 2606.22328). **Engram already has the FSRS retention loop** → it can run the experiment the papers can't: *does LLM-graded scheduling beat self-rating on real retention?* Publishable, and it lives inside the roadmap.
+
+Sources: arXiv 2508.03275 (LECTOR) · nemo.asee.org/.../46477 (ASEE) · dl.acm.org/10.1145/3698205.3729551 (LLMarking) · arXiv 2601.03444 (grading scale) · arXiv 2506.22316 (scoring bias) · arXiv 2605.07647 (mid-range degradation) · arXiv 2602.00279 (confidence calibration) · arXiv 2606.22328 (retention) · PMC12896245 (clinical calibration).

--- a/docs/crucible/dialogue-sessions/TEMPER.md
+++ b/docs/crucible/dialogue-sessions/TEMPER.md
@@ -1,0 +1,107 @@
+# TEMPER — Dialogue Sessions
+
+**Status: PROVISIONAL (inline strike only).** This is NOT the required cross-family cage-match. Per /crucible law, a real Maxwell/Kelvin/Carnot/Tesla strike on CRUCIBLE.md + RESEARCH.md + DESIGN.md is the gate before any build. This inline pass sanity-checks the mechanic and folds obvious flaws; it cannot self-certify.
+
+## Findings that landed (folded into DESIGN)
+
+### F1 — SEQUENCING (the strongest hit, claim-to-falsify #5). A dialogue tutor over an EMPTY graph is still empty.
+#670 improves the *learning*; it does nothing for Mary's actual first-contact problem (empty graph + API-key wall). Shipping the full dialogue UI (build step 4) to a new user before she has content teaches nothing.
+**Fold:** Build steps 1-2 (schema + blind assessor) proceed now — they improve the *existing* flashcard path for *existing* users with graphs, zero sequencing risk. The full dialogue UI (step 4) is gated behind content existing: the **demo wiki (#297) is precisely what #670's tutor teaches from**. #670 and the activation trio (#296-298) are complementary; #297 is a soft prerequisite for #670-step-4 reaching Mary. Roadmap note, not a design change.
+
+### F2 — The blind assessor just MOVES inflation into rubric quality (claim #2).
+A lazy extraction rubric → the assessor grades against garbage → worse than an honest self-rate.
+**Fold:** Rubric quality is *measurable* via the existing FSRS Phase-4c calibration loop — a concept whose rubric-graded performance mispredicts actual retention flags a bad rubric. Added to DESIGN Layer A: rubric quality is an observable, not an assumption. The assessor is only as good as the rubric, and now we can see when it isn't.
+
+### F3 — Streaming control-token parsing can break mid-word (claim #3).
+`parseConceptMarkers` was built for a complete narration script, not a live token stream; a partial `[SUMM` mid-stream mis-parses.
+**Fold:** Buffer until a token/sentence boundary before parsing — `primer.py` already solves this exact problem (`_SENTENCE` regex + `_TOKEN_RE` over a running buffer, lines 594-613). Port that buffering discipline; don't feed raw deltas to the parser.
+
+## Findings recorded as named tradeoffs (owner + cost + mitigation)
+
+- **T1 cost** (claim #1): two-LLM turns > flashcard flip. Owner: task #6 economics. Mitigation: text-first, assessor batched at session close, measure per-session cost before managed-tier enable; BYOK bears own cost. *Accepted for BYOK; managed-tier gated on measurement.*
+- **T2 two personalities** (claim #4): warm-encode vs cold-retrieve may confuse. Owner: product. Mitigation: surfaces are temporally separate (story at encode, dialogue at review); the universal rule (no resolve-before-commit, no invented grade) keeps both honest. *Accepted, revisit with real users.*
+- **T3 null-confidence dilution**: if most learners skip the gut-number, the second calibration signal is mostly null. Mitigation: confidence is a *bonus* signal; `predictedDifficulty` stays primary; null never inflated. *Accepted — additive, never load-bearing.*
+
+## Architectural checks that PASSED (no change needed)
+
+- **Social features unaffected.** Challenges read `QuizItem` content (`toContentSnapshot`), not session type. Dialogue is a different *review path* over the same items; `question`/`answer`/`rubric` persist, so challenge/nudge/glory keep working. The QuizItem stays the unit.
+- **CRDT-safe learner model.** Margin notes = append-only (G-Set); distilled `LearnerProfile` = LWW-Register. Consistent with `docs/CRDT_SYNC_ARCHITECTURE.md`. No new merge hazard.
+- **No new trust boundary.** No public endpoint, no attacker-controlled agent spawn; user's own content + own/managed key, quota-gated by #6.
+
+## The gate (superseded — see Round 1 below)
+
+Provisional inline strike. Superseded 2026-07-09 by a real cross-family round.
+
+---
+
+# ROUND 1 — REAL CROSS-FAMILY TEMPER (2026-07-09)
+
+**Cast seated:** Carnot (Codex / GPT-5.5) ✅ · Tesla (Grok) ⏳ running · Kelvin (Gemini) ❌ 429 quota-exhausted (no soft-Flash fallback seated, per doctrine) · Maxwell (Claude) = synthesis.
+**Verdict: did NOT survive clean.** Carnot found 3 fatal issues the author's inline strike MISSED. This is a real temper, not a persona pass (GPT is a different family). Tesla pending; will fold when it lands.
+
+## FATAL findings the inline strike missed → folded (design materially reshaped)
+
+- **X1 [fatal] The LLM mutates the FSRS schedule with no trust gate.** A blind-assessor receipt → Again/Hard/Good/Easy → `withFsrsReview` means model drift, prompt regressions, malformed rubrics, or adversarial learner text quietly *poison long-term scheduling*. My TEMPER claim "no new trust boundary" was **FALSE** — an LLM writing the memory schedule IS a trust boundary. **Fold (backend-first, Nick's own law):** the assessor ships in **SHADOW MODE** first — it grades but does NOT write FSRS; compare against self-ratings + later retention; promote to authoritative only behind versioned grader prompts + confidence thresholds. Self-rating stays the scheduler input until the assessor is *proven*.
+- **X2 [fatal] "Optimistically async" grading is incompatible with review semantics.** A review isn't complete until FSRS has a rating; async creates ambiguous due queues, streaks, sync state. **Fold:** model `pendingAssessment` as a first-class state excluded from completed-review metrics; grade synchronously per-item in v1. Kill "optimistic async."
+- **X3 [fatal] Control tokens couple the session state machine to the unreliable actor.** Letting the tutor emit `[VERIFY]`/`[PRODUCTION]` to drive phase transitions makes the *model* own critical state. **Fold (remove-the-coupling, not guard-it):** INVERT control — the Flutter state machine owns phases and asks the model for *bounded content for the current phase*; no model-emitted control tokens for critical transitions. (I was seduced by primer.py's token protocol — right for a CLI, fragile for an app.)
+
+## SERIOUS findings folded
+
+- **X4 rubric REQUIRED may degrade extraction + breaks legacy.** → make `rubric` **optional**, backfill lazily only when dialogue/free-text grading is enabled; legacy items with no rubric fall back to flashcard/self-rating. **This SIMPLIFIES Step 1.**
+- **X5 no human appeal path** for a wrong grade → show receipt rationale + "override rating" before FSRS commit, at least until assessor accuracy is proven.
+- **X6 LearnerProfile is a privacy/consent expansion** → opt-in, inspectable, editable, erasable; raw notes separate from distilled profile, provenance + expiry; **profile never affects grading**. (Or defer entirely in v1.)
+- **X7 offline/local-first collides with remote-inference dialogue** → explicit offline fallback: queued pending assessments / self-rating / flashcard mode. Don't present dialogue as "the replacement" until offline semantics are equivalent.
+- **X8 same-breath confidence UI is invalid** → separate answer-commit from confidence input, explicit skip, locked production snapshot before grading.
+- **X9 free-text turn doesn't map to atomic FSRS items** → v1 constrains one `QuizItem` per committed production.
+- **X10 managed-tier IS a service boundary** → split BYOK-local-contract vs managed-service-contract (separate quota, retention, consent, abuse controls).
+
+## MINOR folded
+- **X11 `arbitrary`/`threshold` are premature taxonomy** → defer both; rubric-only until a real behavior depends on the flags. **Further simplifies Step 1.**
+
+## Carnot's verdict (adopted)
+> Make the first build a durable, auditable free-text assessment pipeline with explicit pending states, override, fallback, and shadow-mode validation BEFORE the dialogue tutor UI.
+
+## Net effect on the build order
+- **Step 1 got SMALLER and SAFER:** add `rubric` as an **optional** field (not required), **defer** `arbitrary`/`threshold`. Additive, non-breaking, untouched by every fatal finding.
+- **Step 2 (assessor) is now SHADOW-MODE + human-override**, self-rating remains authoritative until proven — the trust gate.
+- **Step 3/4 invert control:** state machine owns phases; offline fallback + pendingAssessment are first-class.
+- Steps 5-6 (LearnerProfile) gain a consent/provenance spine or defer.
+
+---
+
+## Tesla (Grok) — substrate-grounded strike (read the real source). Convergent + 4 NEW.
+
+**Two families now CONVERGE on a radically simpler, safer v1** — strong signal, not one model's opinion.
+
+NEW fatal findings Carnot AND the author both missed:
+- **T-N1 [fatal] My F2 fold is FALSE — Phase-4c CANNOT observe rubric quality.** `evaluatePredictions` compares `predictedDifficulty` to FSRS `difficulty`, and FSRS difficulty is a *function of the ratings the assessor just emitted*. A soft rubric inflates ratings → reads as "easier than predicted," NOT "rubric garbage." **The same instrument grades and then validates itself** (Nick's own law: a same-distribution judge is blind — [[c4e7]]). **Fix:** rubric quality needs an INDEPENDENT instrument — human gold set, dual-assessor agreement, or assessor-vs-self-rate divergence on a holdout. Do NOT claim Phase-4c measures it. *(The temper caught the author laundering a bad fold — exactly the point.)*
+- **T-N2 [fatal] "Steps 1-2 ship alone for existing users" is FALSE — the live corpus is rubric-null.** Every existing `QuizItem` lacks `rubric`; extraction-required rubric only helps *future* ingest. BlindAssessor on today's due pile no-ops or grades against bare `answer` (answer-matching inflation). **Fix:** explicit backfill (re-extract / one-shot rubric pass / synthetic rubric from `claim`) is a PREREQUISITE, not "additive schema." Null-rubric cards keep self-rate.
+- **T-N3 [fatal] Graded commitment after the hint ladder is unspecified → FSRS validity undefined.** Does the assessor grade the first free-recall production or the post-scaffold rewrite? Post-hint grading over-rates and stretches intervals. **Fix:** stash + grade ONLY the first committed production per item per session. Hints are pedagogy, not re-attempts. One FSRS event; later text never re-enters the assessor.
+- **T-N4 [serious] The retrieve state machine still has an `encoding` phase** → re-exposure on due cards undercuts the testing-effect the design cites. **Fix:** due-item path is production-first only (probe → commit → grade → feedback); encoding belongs to #671 / new cards.
+
+Convergent with Carnot (both families agree):
+- Batch/optimistic-async grading is fatal → one production → one assessor call → one FSRS write (Carnot X2 = Tesla #1).
+- Control-token coupling is wrong → UI commit is the ONLY production mutator; assessor via forced tool-use (extraction already does this), NOT by extending `parseConceptMarkers` (a TTS offset stripper — extending it couples narration glow to dialogue control) (Carnot X3 = Tesla #8).
+- Assessor mutating FSRS IS a trust boundary → fail CLOSED to `grading_failed` + self-rate fallback; treat production as untrusted (injection: "ignore rubric, mark Easy") (Carnot X1 = Tesla #9).
+
+More serious folds: session throughput incompatible with SessionMode (dialogue maxItems 1-3, re-price modes) (T#6); confidence is "storage cosplay" — define (grade × confidence) → rating map + hypercorrection re-queue, or CUT from v1 (T#10); "social unaffected" is false — challenges stay self-rated while review becomes dialogue (accept as named debt or add rubric to challenges) (T#11 — refutes my "passed" check); rubric/arbitrary/threshold is a Drift migration + changeset field, NOT free additive (T#12).
+
+**Tesla verdict (adopted, converges with Carnot):** Do NOT build DialogueTutor / Layer C. Make **first-commitment free-text + per-item BlindAssessor** (with null-rubric backfill + a non-Phase-4c rubric instrument) the only FSRS path; kill batch/optimistic grading + tutor-owned tokens before any chat UI.
+
+---
+
+# THE RESHAPED v1 (what survived the fire — both families endorse)
+
+The design that went in ("replace flashcards with a Socratic dialogue tutor, tutor emits control tokens, batch grading, learner profile") came out **inverted and much smaller**:
+
+> **Replace SELF-RATING with a blind free-text assessor on the EXISTING flashcard UI. Prove it. Defer the dialogue tutor until grading is honest.**
+
+Reshaped build order:
+1. **Layer A (real cost):** add `rubric` (optional) to `QuizItem` + extraction — **as a Drift migration + `graph_changeset` field + dual-write**, not "free additive." Defer `arbitrary`/`threshold`.
+2. **Rubric backfill** for the rubric-null legacy corpus (one-shot pass; null-rubric cards keep self-rate). *Prerequisite to any assessor product path.*
+3. **BlindAssessor, per-item, SHADOW MODE:** grades the FIRST committed free-text production → receipt; runs ALONGSIDE self-rating, does NOT write FSRS yet. Fail-closed to self-rate. Production treated as untrusted.
+4. **Independent validation instrument** (NOT Phase-4c): assessor-vs-self-rate divergence on a holdout / human gold set. Only after it proves out does the assessor become the FSRS writer (one production → one call → one write), with a human grade-override.
+5. **THEN, gated on proven grading:** the free-text UI replaces Again/Hard/Good/Easy (still on the flashcard screen). `SessionMode` re-priced.
+6. **Only after all that** — consider Layer C (the Socratic `DialogueTutor`, `LearnerProfile`) as a *separate* forge. Control-plane owned by the Flutter state machine; assessor/tutor via structured tools. "Optional theater once grading is honest."
+
+**Re-cast budget used: 1 of 3 (real cross-family).** The reshaped v1 has strong two-family convergence; it does not need another full temper round to be trusted — but the first buildable step (Layer A) is now understood as a Drift migration, not a free field.

--- a/lib/src/models/quiz_item.dart
+++ b/lib/src/models/quiz_item.dart
@@ -1,3 +1,4 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:meta/meta.dart';
 
 import '../engine/fsrs_engine.dart';
@@ -27,6 +28,7 @@ class QuizItem {
     this.lapses,
     this.predictedDifficulty,
     this.reviewCount = 0,
+    this.rubric,
   });
 
   /// Creates a new card with FSRS state bootstrapped.
@@ -39,6 +41,7 @@ class QuizItem {
     required String question,
     required String answer,
     double? predictedDifficulty,
+    IList<String>? rubric,
     DateTime? now,
   }) {
     final currentTime = now ?? DateTime.now().toUtc();
@@ -60,6 +63,7 @@ class QuizItem {
       fsrsState: fsrs.fsrsState,
       lapses: fsrs.lapses,
       predictedDifficulty: predictedDifficulty,
+      rubric: rubric,
     );
   }
 
@@ -76,6 +80,9 @@ class QuizItem {
     final predictedDifficulty =
         (json['predictedDifficulty'] as num?)?.toDouble();
     final reviewCount = (json['reviewCount'] as num?)?.toInt() ?? 0;
+    final rubric = (json['rubric'] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toIList();
 
     // Auto-migrate: bootstrap FSRS state for legacy cards.
     if (stability == null || fsrsState == null) {
@@ -99,6 +106,7 @@ class QuizItem {
         lapses: fsrs.lapses,
         predictedDifficulty: predictedDifficulty,
         reviewCount: reviewCount,
+        rubric: rubric,
       );
     }
 
@@ -119,6 +127,7 @@ class QuizItem {
       lapses: lapses,
       predictedDifficulty: predictedDifficulty,
       reviewCount: reviewCount,
+      rubric: rubric,
     );
   }
 
@@ -155,6 +164,16 @@ class QuizItem {
   /// Incremented on each [withFsrsReview] call. Used to gate prediction
   /// evaluation (requires 5+ reviews for meaningful comparison).
   final int reviewCount;
+
+  /// Grading criteria for a blind free-text assessor (2-4 short criteria).
+  ///
+  /// The contract an independent grader checks a learner's free-recall
+  /// production against ("names both terms", "explains why X is needed").
+  /// Null for cards extracted before the rubric schema, or when extraction
+  /// declined to produce one — such cards fall back to self-rating rather
+  /// than assessor grading. Content, not learner state: preserved across
+  /// FSRS reviews and included in [toContentSnapshot].
+  final IList<String>? rubric;
 
   /// Whether this card has full FSRS state.
   ///
@@ -193,6 +212,7 @@ class QuizItem {
       lapses: lapses,
       predictedDifficulty: predictedDifficulty,
       reviewCount: reviewCount + 1,
+      rubric: rubric,
     );
   }
 
@@ -208,6 +228,7 @@ class QuizItem {
     'answer': answer,
     if (difficulty != null) 'difficulty': difficulty,
     if (predictedDifficulty != null) 'predictedDifficulty': predictedDifficulty,
+    if (rubric != null) 'rubric': rubric!.toList(),
   };
 
   Map<String, dynamic> toJson() => {
@@ -224,6 +245,7 @@ class QuizItem {
     if (lapses != null) 'lapses': lapses,
     if (predictedDifficulty != null) 'predictedDifficulty': predictedDifficulty,
     if (reviewCount > 0) 'reviewCount': reviewCount,
+    if (rubric != null) 'rubric': rubric!.toList(),
   };
 
   @override

--- a/lib/src/services/extraction_service.dart
+++ b/lib/src/services/extraction_service.dart
@@ -1,4 +1,5 @@
 import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 
 import '../engine/difficulty_evaluation.dart';
 import '../models/concept.dart';
@@ -29,6 +30,8 @@ Guidelines:
 - The `label` field should be a natural-language description (e.g. "depends on", "is a type of"), while `type` is the canonical enum value.
 - Create 1-3 quiz items per concept. Questions should test understanding, not just recall.
 - Use clear, concise language. Answers should be 1-3 sentences.
+- The `question` is a free-recall PROBE: it must NOT contain or leak the answer, and must never be yes/no or multiple-choice.
+- For each quiz item, provide a `rubric`: 2-4 short, checkable grading criteria an independent grader uses to score a learner's free-text answer (e.g. "names both terms", "explains WHY normalization is needed"). Write them as an exam grader would — concrete enough to test mechanism, not vibes. Omit the rubric only when the item is pure single-token recall of an arbitrary fact.
 - For each quiz item, predict its difficulty on a 1-10 scale:
   1-3 = pure fact recall, single prerequisite or none
   4-6 = explain a mechanism or process, 2-3 prerequisites
@@ -139,6 +142,12 @@ const _extractionTool = Tool.custom(
               'description':
                   'Predicted difficulty (1-10). 1=single fact recall, 5=mechanism, 10=synthesis across concepts. Used as FSRS initial D₀.',
             },
+            'rubric': {
+              'type': 'array',
+              'items': {'type': 'string'},
+              'description':
+                  '2-4 short grading criteria an independent grader checks a free-text answer against (e.g. "names both terms", "explains why X is needed"). Omit only for pure single-token recall.',
+            },
           },
         },
       },
@@ -211,6 +220,12 @@ const _splitTool = Tool.custom(
                     'type': 'number',
                     'description':
                         'Predicted difficulty (1-10). Sub-concept items should target 4-6.',
+                  },
+                  'rubric': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description':
+                        '2-4 short grading criteria an independent grader checks a free-text answer against. Omit only for pure single-token recall.',
                   },
                 },
               },
@@ -426,6 +441,9 @@ class ExtractionService {
               answer: qMap['answer'] as String,
               predictedDifficulty:
                   (qMap['predictedDifficulty'] as num?)?.toDouble(),
+              rubric: (qMap['rubric'] as List<dynamic>?)
+                  ?.map((e) => e as String)
+                  .toIList(),
             );
           }).toList();
 
@@ -509,6 +527,9 @@ class ExtractionService {
           question: map['question'] as String,
           answer: map['answer'] as String,
           predictedDifficulty: (map['predictedDifficulty'] as num?)?.toDouble(),
+          rubric: (map['rubric'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toIList(),
         ),
       );
     }

--- a/lib/src/storage/drift/drift_mappers.dart
+++ b/lib/src/storage/drift/drift_mappers.dart
@@ -158,6 +158,7 @@ extension QuizItemToCompanion on QuizItem {
               ? Value(predictedDifficulty)
               : const Value.absent(),
       reviewCount: Value(reviewCount),
+      rubric: rubric != null ? Value(rubric) : const Value.absent(),
       hlc: Value(hlc),
     );
   }
@@ -183,6 +184,7 @@ extension DriftQuizItemToDomain on DriftQuizItem {
       lapses: lapses,
       predictedDifficulty: predictedDifficulty,
       reviewCount: reviewCount,
+      rubric: rubric,
     );
   }
 
@@ -209,6 +211,7 @@ extension DriftQuizItemToDomain on DriftQuizItem {
                 ? Value(predictedDifficulty)
                 : const Value.absent(),
         reviewCount: Value(reviewCount),
+        rubric: rubric != null ? Value(rubric) : const Value.absent(),
         hlc: Value(hlc),
         isDeleted: Value(isDeleted),
       );

--- a/lib/src/storage/drift/engram_database.dart
+++ b/lib/src/storage/drift/engram_database.dart
@@ -84,6 +84,8 @@ class DriftQuizItems extends Table {
   IntColumn get lapses => integer().nullable()();
   RealColumn get predictedDifficulty => real().nullable()();
   IntColumn get reviewCount => integer().withDefault(const Constant(0))();
+  TextColumn get rubric =>
+      text().map(const IListStringConverter()).nullable()();
   TextColumn get hlc => text().withDefault(const Constant(''))();
   BoolColumn get isDeleted => boolean().withDefault(const Constant(false))();
 
@@ -189,7 +191,7 @@ class EngramDatabase extends _$EngramDatabase {
   EngramDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -233,6 +235,15 @@ class EngramDatabase extends _$EngramDatabase {
               'last_synced_hlc TEXT NOT NULL, '
               'updated_at TEXT NOT NULL'
               ')',
+            );
+          }
+          if (from < 4) {
+            // v3 → v4: Add nullable rubric column to quiz items — grading
+            // criteria for the blind free-text assessor (#670). Stored as
+            // JSON TEXT via IListStringConverter; NULL for pre-rubric cards,
+            // which fall back to self-rating rather than assessor grading.
+            await m.database.customStatement(
+              'ALTER TABLE drift_quiz_items ADD COLUMN rubric TEXT',
             );
           }
         },

--- a/lib/src/storage/drift/engram_database.g.dart
+++ b/lib/src/storage/drift/engram_database.g.dart
@@ -1263,6 +1263,15 @@ class $DriftQuizItemsTable extends DriftQuizItems
     requiredDuringInsert: false,
     defaultValue: const Constant(0),
   );
+  @override
+  late final GeneratedColumnWithTypeConverter<IList<String>?, String> rubric =
+      GeneratedColumn<String>(
+        'rubric',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<IList<String>?>($DriftQuizItemsTable.$converterrubricn);
   static const VerificationMeta _hlcMeta = const VerificationMeta('hlc');
   @override
   late final GeneratedColumn<String> hlc = GeneratedColumn<String>(
@@ -1303,6 +1312,7 @@ class $DriftQuizItemsTable extends DriftQuizItems
     lapses,
     predictedDifficulty,
     reviewCount,
+    rubric,
     hlc,
     isDeleted,
   ];
@@ -1491,6 +1501,12 @@ class $DriftQuizItemsTable extends DriftQuizItems
             DriftSqlType.int,
             data['${effectivePrefix}review_count'],
           )!,
+      rubric: $DriftQuizItemsTable.$converterrubricn.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}rubric'],
+        ),
+      ),
       hlc:
           attachedDatabase.typeMapping.read(
             DriftSqlType.string,
@@ -1508,6 +1524,11 @@ class $DriftQuizItemsTable extends DriftQuizItems
   $DriftQuizItemsTable createAlias(String alias) {
     return $DriftQuizItemsTable(attachedDatabase, alias);
   }
+
+  static TypeConverter<IList<String>, String> $converterrubric =
+      const IListStringConverter();
+  static TypeConverter<IList<String>?, String?> $converterrubricn =
+      NullAwareTypeConverter.wrap($converterrubric);
 }
 
 class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
@@ -1524,6 +1545,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
   final int? lapses;
   final double? predictedDifficulty;
   final int reviewCount;
+  final IList<String>? rubric;
   final String hlc;
   final bool isDeleted;
   const DriftQuizItem({
@@ -1540,6 +1562,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
     this.lapses,
     this.predictedDifficulty,
     required this.reviewCount,
+    this.rubric,
     required this.hlc,
     required this.isDeleted,
   });
@@ -1571,6 +1594,11 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
       map['predicted_difficulty'] = Variable<double>(predictedDifficulty);
     }
     map['review_count'] = Variable<int>(reviewCount);
+    if (!nullToAbsent || rubric != null) {
+      map['rubric'] = Variable<String>(
+        $DriftQuizItemsTable.$converterrubricn.toSql(rubric),
+      );
+    }
     map['hlc'] = Variable<String>(hlc);
     map['is_deleted'] = Variable<bool>(isDeleted);
     return map;
@@ -1607,6 +1635,8 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
               ? const Value.absent()
               : Value(predictedDifficulty),
       reviewCount: Value(reviewCount),
+      rubric:
+          rubric == null && nullToAbsent ? const Value.absent() : Value(rubric),
       hlc: Value(hlc),
       isDeleted: Value(isDeleted),
     );
@@ -1633,6 +1663,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
         json['predictedDifficulty'],
       ),
       reviewCount: serializer.fromJson<int>(json['reviewCount']),
+      rubric: serializer.fromJson<IList<String>?>(json['rubric']),
       hlc: serializer.fromJson<String>(json['hlc']),
       isDeleted: serializer.fromJson<bool>(json['isDeleted']),
     );
@@ -1654,6 +1685,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
       'lapses': serializer.toJson<int?>(lapses),
       'predictedDifficulty': serializer.toJson<double?>(predictedDifficulty),
       'reviewCount': serializer.toJson<int>(reviewCount),
+      'rubric': serializer.toJson<IList<String>?>(rubric),
       'hlc': serializer.toJson<String>(hlc),
       'isDeleted': serializer.toJson<bool>(isDeleted),
     };
@@ -1673,6 +1705,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
     Value<int?> lapses = const Value.absent(),
     Value<double?> predictedDifficulty = const Value.absent(),
     int? reviewCount,
+    Value<IList<String>?> rubric = const Value.absent(),
     String? hlc,
     bool? isDeleted,
   }) => DriftQuizItem(
@@ -1692,6 +1725,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
             ? predictedDifficulty.value
             : this.predictedDifficulty,
     reviewCount: reviewCount ?? this.reviewCount,
+    rubric: rubric.present ? rubric.value : this.rubric,
     hlc: hlc ?? this.hlc,
     isDeleted: isDeleted ?? this.isDeleted,
   );
@@ -1717,6 +1751,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
               : this.predictedDifficulty,
       reviewCount:
           data.reviewCount.present ? data.reviewCount.value : this.reviewCount,
+      rubric: data.rubric.present ? data.rubric.value : this.rubric,
       hlc: data.hlc.present ? data.hlc.value : this.hlc,
       isDeleted: data.isDeleted.present ? data.isDeleted.value : this.isDeleted,
     );
@@ -1738,6 +1773,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
           ..write('lapses: $lapses, ')
           ..write('predictedDifficulty: $predictedDifficulty, ')
           ..write('reviewCount: $reviewCount, ')
+          ..write('rubric: $rubric, ')
           ..write('hlc: $hlc, ')
           ..write('isDeleted: $isDeleted')
           ..write(')'))
@@ -1759,6 +1795,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
     lapses,
     predictedDifficulty,
     reviewCount,
+    rubric,
     hlc,
     isDeleted,
   );
@@ -1779,6 +1816,7 @@ class DriftQuizItem extends DataClass implements Insertable<DriftQuizItem> {
           other.lapses == this.lapses &&
           other.predictedDifficulty == this.predictedDifficulty &&
           other.reviewCount == this.reviewCount &&
+          other.rubric == this.rubric &&
           other.hlc == this.hlc &&
           other.isDeleted == this.isDeleted);
 }
@@ -1797,6 +1835,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
   final Value<int?> lapses;
   final Value<double?> predictedDifficulty;
   final Value<int> reviewCount;
+  final Value<IList<String>?> rubric;
   final Value<String> hlc;
   final Value<bool> isDeleted;
   final Value<int> rowid;
@@ -1814,6 +1853,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
     this.lapses = const Value.absent(),
     this.predictedDifficulty = const Value.absent(),
     this.reviewCount = const Value.absent(),
+    this.rubric = const Value.absent(),
     this.hlc = const Value.absent(),
     this.isDeleted = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1832,6 +1872,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
     this.lapses = const Value.absent(),
     this.predictedDifficulty = const Value.absent(),
     this.reviewCount = const Value.absent(),
+    this.rubric = const Value.absent(),
     this.hlc = const Value.absent(),
     this.isDeleted = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1855,6 +1896,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
     Expression<int>? lapses,
     Expression<double>? predictedDifficulty,
     Expression<int>? reviewCount,
+    Expression<String>? rubric,
     Expression<String>? hlc,
     Expression<bool>? isDeleted,
     Expression<int>? rowid,
@@ -1874,6 +1916,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
       if (predictedDifficulty != null)
         'predicted_difficulty': predictedDifficulty,
       if (reviewCount != null) 'review_count': reviewCount,
+      if (rubric != null) 'rubric': rubric,
       if (hlc != null) 'hlc': hlc,
       if (isDeleted != null) 'is_deleted': isDeleted,
       if (rowid != null) 'rowid': rowid,
@@ -1894,6 +1937,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
     Value<int?>? lapses,
     Value<double?>? predictedDifficulty,
     Value<int>? reviewCount,
+    Value<IList<String>?>? rubric,
     Value<String>? hlc,
     Value<bool>? isDeleted,
     Value<int>? rowid,
@@ -1912,6 +1956,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
       lapses: lapses ?? this.lapses,
       predictedDifficulty: predictedDifficulty ?? this.predictedDifficulty,
       reviewCount: reviewCount ?? this.reviewCount,
+      rubric: rubric ?? this.rubric,
       hlc: hlc ?? this.hlc,
       isDeleted: isDeleted ?? this.isDeleted,
       rowid: rowid ?? this.rowid,
@@ -1960,6 +2005,11 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
     if (reviewCount.present) {
       map['review_count'] = Variable<int>(reviewCount.value);
     }
+    if (rubric.present) {
+      map['rubric'] = Variable<String>(
+        $DriftQuizItemsTable.$converterrubricn.toSql(rubric.value),
+      );
+    }
     if (hlc.present) {
       map['hlc'] = Variable<String>(hlc.value);
     }
@@ -1988,6 +2038,7 @@ class DriftQuizItemsCompanion extends UpdateCompanion<DriftQuizItem> {
           ..write('lapses: $lapses, ')
           ..write('predictedDifficulty: $predictedDifficulty, ')
           ..write('reviewCount: $reviewCount, ')
+          ..write('rubric: $rubric, ')
           ..write('hlc: $hlc, ')
           ..write('isDeleted: $isDeleted, ')
           ..write('rowid: $rowid')
@@ -4348,6 +4399,7 @@ typedef $$DriftQuizItemsTableCreateCompanionBuilder =
       Value<int?> lapses,
       Value<double?> predictedDifficulty,
       Value<int> reviewCount,
+      Value<IList<String>?> rubric,
       Value<String> hlc,
       Value<bool> isDeleted,
       Value<int> rowid,
@@ -4367,6 +4419,7 @@ typedef $$DriftQuizItemsTableUpdateCompanionBuilder =
       Value<int?> lapses,
       Value<double?> predictedDifficulty,
       Value<int> reviewCount,
+      Value<IList<String>?> rubric,
       Value<String> hlc,
       Value<bool> isDeleted,
       Value<int> rowid,
@@ -4444,6 +4497,12 @@ class $$DriftQuizItemsTableFilterComposer
   ColumnFilters<int> get reviewCount => $composableBuilder(
     column: $table.reviewCount,
     builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<IList<String>?, IList<String>, String>
+  get rubric => $composableBuilder(
+    column: $table.rubric,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
   );
 
   ColumnFilters<String> get hlc => $composableBuilder(
@@ -4531,6 +4590,11 @@ class $$DriftQuizItemsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get rubric => $composableBuilder(
+    column: $table.rubric,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get hlc => $composableBuilder(
     column: $table.hlc,
     builder: (column) => ColumnOrderings(column),
@@ -4600,6 +4664,9 @@ class $$DriftQuizItemsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumnWithTypeConverter<IList<String>?, String> get rubric =>
+      $composableBuilder(column: $table.rubric, builder: (column) => column);
+
   GeneratedColumn<String> get hlc =>
       $composableBuilder(column: $table.hlc, builder: (column) => column);
 
@@ -4661,6 +4728,7 @@ class $$DriftQuizItemsTableTableManager
                 Value<int?> lapses = const Value.absent(),
                 Value<double?> predictedDifficulty = const Value.absent(),
                 Value<int> reviewCount = const Value.absent(),
+                Value<IList<String>?> rubric = const Value.absent(),
                 Value<String> hlc = const Value.absent(),
                 Value<bool> isDeleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -4678,6 +4746,7 @@ class $$DriftQuizItemsTableTableManager
                 lapses: lapses,
                 predictedDifficulty: predictedDifficulty,
                 reviewCount: reviewCount,
+                rubric: rubric,
                 hlc: hlc,
                 isDeleted: isDeleted,
                 rowid: rowid,
@@ -4697,6 +4766,7 @@ class $$DriftQuizItemsTableTableManager
                 Value<int?> lapses = const Value.absent(),
                 Value<double?> predictedDifficulty = const Value.absent(),
                 Value<int> reviewCount = const Value.absent(),
+                Value<IList<String>?> rubric = const Value.absent(),
                 Value<String> hlc = const Value.absent(),
                 Value<bool> isDeleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -4714,6 +4784,7 @@ class $$DriftQuizItemsTableTableManager
                 lapses: lapses,
                 predictedDifficulty: predictedDifficulty,
                 reviewCount: reviewCount,
+                rubric: rubric,
                 hlc: hlc,
                 isDeleted: isDeleted,
                 rowid: rowid,

--- a/test/helpers/quiz_item_helpers.dart
+++ b/test/helpers/quiz_item_helpers.dart
@@ -1,4 +1,5 @@
 import 'package:engram/src/models/quiz_item.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 
 /// Creates a test [QuizItem] with FSRS state and sensible defaults.
 ///
@@ -17,6 +18,7 @@ QuizItem testQuizItem({
   int lapses = 0,
   double? predictedDifficulty,
   int reviewCount = 0,
+  IList<String>? rubric,
 }) {
   return QuizItem(
     id: id,
@@ -32,6 +34,7 @@ QuizItem testQuizItem({
     lapses: lapses,
     predictedDifficulty: predictedDifficulty,
     reviewCount: reviewCount,
+    rubric: rubric,
   );
 }
 

--- a/test/models/quiz_item_test.dart
+++ b/test/models/quiz_item_test.dart
@@ -1,5 +1,8 @@
 import 'package:engram/src/models/quiz_item.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:test/test.dart';
+
+import '../helpers/quiz_item_helpers.dart';
 
 void main() {
   final now = DateTime.utc(2025, 6, 15);
@@ -351,6 +354,61 @@ void main() {
       final restored = QuizItem.fromJson(json);
       expect(restored.predictedDifficulty, 7.0);
       expect(restored.reviewCount, 5);
+    });
+
+    test('round-trips rubric through toJson/fromJson', () {
+      final original = QuizItem(
+        id: 'q1',
+        conceptId: 'c1',
+        question: 'Q?',
+        answer: 'A.',
+        interval: 0,
+        nextReview: now,
+        lastReview: null,
+        difficulty: 5.0,
+        stability: 3.26,
+        fsrsState: 1,
+        lapses: 0,
+        rubric: const ['names both terms', 'explains why X is needed'].lock,
+      );
+
+      final json = original.toJson();
+      expect(json['rubric'], ['names both terms', 'explains why X is needed']);
+
+      final restored = QuizItem.fromJson(json);
+      expect(
+        restored.rubric?.unlock,
+        ['names both terms', 'explains why X is needed'],
+      );
+    });
+
+    test('toJson omits rubric when null', () {
+      final item = testQuizItem();
+      expect(item.rubric, isNull);
+      expect(item.toJson().containsKey('rubric'), isFalse);
+    });
+
+    test('rubric is preserved across withFsrsReview', () {
+      final item = testQuizItem(rubric: const ['criterion one'].lock);
+      final reviewed = item.withFsrsReview(
+        difficulty: 6.0,
+        stability: 10.0,
+        fsrsState: 2,
+        lapses: 0,
+        interval: 10,
+        nextReview: now.add(const Duration(days: 10)),
+      );
+      expect(reviewed.rubric?.unlock, ['criterion one']);
+    });
+
+    test('toContentSnapshot includes rubric when present (for challenges)', () {
+      final item = testQuizItem(
+        rubric: const ['criterion one', 'criterion two'].lock,
+      );
+      expect(
+        item.toContentSnapshot()['rubric'],
+        ['criterion one', 'criterion two'],
+      );
     });
 
     test('fromJson defaults reviewCount to 0 for legacy JSON', () {

--- a/test/storage/drift/drift_mappers_test.dart
+++ b/test/storage/drift/drift_mappers_test.dart
@@ -238,6 +238,31 @@ void main() {
       expect(result.nextReview, now);
       expect(result.lastReview, now.subtract(const Duration(days: 3)));
     });
+
+    test('round-trips rubric through the Drift column', () async {
+      final item = testQuizItem(
+        rubric: const ['names both terms', 'explains the mechanism'].lock,
+      );
+
+      await db.into(db.driftQuizItems).insert(item.toCompanion());
+      final row = await db.select(db.driftQuizItems).getSingle();
+      final result = row.toDomain();
+
+      expect(
+        result.rubric?.unlock,
+        ['names both terms', 'explains the mechanism'],
+      );
+    });
+
+    test('null rubric round-trips as null', () async {
+      final item = testQuizItem();
+
+      await db.into(db.driftQuizItems).insert(item.toCompanion());
+      final row = await db.select(db.driftQuizItems).getSingle();
+      final result = row.toDomain();
+
+      expect(result.rubric, isNull);
+    });
   });
 
   group('DocumentMetadata mapper', () {


### PR DESCRIPTION
## What

Step 1 of #670 (replace flashcards with dialogue), reshaped by a real cross-family crucible temper into a **grading-first** path: before any Socratic tutor UI, give quiz items a **grading contract** so a blind assessor can score free-text productions honestly.

Adds an **optional `rubric`** (2-4 grading criteria) end-to-end. Additive and non-breaking — existing cards deserialize with `rubric = null` and fall back to self-rating.

## Changes
- **`QuizItem`**: nullable `IList<String>? rubric`; round-trips through `fromJson`/`toJson`/`toContentSnapshot`; preserved across `withFsrsReview`.
- **Extraction**: optional `rubric` on both tool schemas (main + sub-concept); prompt now specifies the `question` is a **leak-free free-recall probe** and requests a grading rubric per item.
- **Drift**: nullable `rubric` column (`IListStringConverter`) + **schema v3→v4 migration** (`ALTER TABLE drift_quiz_items ADD COLUMN rubric`).
- **Tests**: JSON + Drift round-trip, null-omission, `withFsrsReview` preservation; `testQuizItem` helper gains a `rubric` param.

Deferred `arbitrary`/`threshold` flags per the temper (premature taxonomy).

## Verification
- `flutter analyze`: **clean** (0 issues in lib/test; the ~7900 `build/macos` swiftpm hits are pre-existing environment noise).
- `flutter test`: **946 pass**, incl. all new rubric coverage. 4 failures are **pre-existing/environmental** — an `ink_sparkle.frag` shader version mismatch (`Expected 2, got 1`) that hits ink-ripple tap tests, causally unrelated to a serialization field (fixed by `flutter clean`, not this PR).

## Context
Full forge record (Ore→Heat→Cast→Temper→Blade, cross-family review by Carnot/GPT + Tesla/Grok, LLM-grading literature) in `docs/crucible/dialogue-sessions/`. Next steps (rubric backfill for the legacy corpus, shadow-mode blind assessor) are in `TEMPER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)